### PR TITLE
Update AWSLambda_ReadOnlyAccess policy name

### DIFF
--- a/sample-apps/python-lambda/template.yml
+++ b/sample-apps/python-lambda/template.yml
@@ -19,7 +19,7 @@ Resources:
       Timeout: 15
       Policies:
         - AWSLambdaBasicExecutionRole
-        - AWSLambdaReadOnlyAccess
+        - AWSLambda_ReadOnlyAccess
         - AWSXrayWriteOnlyAccess
       ReservedConcurrentExecutions: 1
       Environment:


### PR DESCRIPTION
**Description:** This fixes a defect in Template.yml file which specifies an invalid policy name.

**Link to tracking Issue:** N/A

**Testing:** Manually tested by running the `run.sh` script. Before change I had encountered the following CloudFormation error `ARN AWSLambdaReadOnlyAccess is not valid`. After the change the CloudFormation stack was able to successfully deploy.
**Documentation:** N/A
