### PR TITLE
otel-lambda adot downstream repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+**Description:** <Describe what has changed. 
+Ex. Fixing a bug - Describe the bug and how this fixes the issue.
+Ex. Adding a feature - Explain what this achieves.>
+
+**Link to tracking Issue:** <Issue number if applicable>
+
+**Testing:** < Describe what testing was performed and which tests were added.>
+
+**Documentation:** < Describe the documentation added.>

--- a/.github/workflows/canary-py.yml
+++ b/.github/workflows/canary-py.yml
@@ -1,0 +1,85 @@
+name: canary-python
+env:
+  STACK: py38-canary
+  UTILS: ${{ github.workspace }}/opentelemetry-lambda/utils/sam
+
+on:
+  schedule:
+    - cron: '15 * * * *' # every hour
+  workflow_dispatch:
+
+jobs:
+  canary-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        region: [ us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, eu-south-1]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --recursive
+          cd opentelemetry-lambda
+          git fetch
+          git merge origin/master
+
+      - name: adot custom
+        run: |
+          cp -rf adot/* opentelemetry-lambda/
+
+      - name: Configure AWS Credentials CN
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region == 'cn-north-1' ||  matrix.region == 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_CN }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_CN }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+      - name: Configure AWS Credentials standard
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region != 'cn-north-1' &&  matrix.region != 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+
+      - name: Get git commit sha
+        run: |
+          echo "ADOT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          cd opentelemetry-lambda
+          echo "OTEL_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Checkout test framework
+        uses: actions/checkout@v2
+        if: ${{ success() }}
+        with:
+          repository: aws-observability/aws-otel-test-framework
+          path: test-framework
+
+      - name: Set sample stack name
+        run: |
+          echo "OTEL_LAMBDA_STACK=$STACK-$OTEL_SHA-$ADOT_SHA" >> $GITHUB_ENV
+
+      - name: deploy sample
+        continue-on-error: true
+        working-directory: opentelemetry-lambda/python/sample-xray
+        run: |
+          echo $OTEL_LAMBDA_STACK
+          ./run.sh
+
+      - name: validate sample
+        run: |
+          endpoint=$(${{ env.UTILS }}/endpoint.sh)
+          curl $endpoint
+          cp opentelemetry-lambda/python/sample-xray/test/expected.mustache test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cd test-framework
+          ./gradlew :validator:run  --args="-c default-lambda-validation.yml --endpoint $endpoint --region $AWS_REGION"
+
+      - name: clean sample
+        run: |
+          ${{ env.UTILS }}/clean.sh

--- a/.github/workflows/integration-py.yml
+++ b/.github/workflows/integration-py.yml
@@ -1,0 +1,127 @@
+name: integration-python
+env:
+  LAYER: py38-layer
+  LAYER_PATH: 'opentelemetry-lambda/python/src'
+  STACK: py38-sample
+  UTILS: ${{ github.workspace }}/opentelemetry-lambda/utils/sam
+
+on:
+  workflow_dispatch:
+    inputs:
+      reserve:
+        description: 'reserve'
+        required: false
+        default: 'reserve'
+  schedule:
+    - cron: '5 * * * *' # every hour
+  push:
+    branches: [ main ]
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        region: [ us-west-2 ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --recursive
+          cd opentelemetry-lambda
+          git fetch
+          git merge origin/master
+
+      - name: adot custom
+        run: |
+          cp -rf adot/* opentelemetry-lambda/
+
+      - name: Configure AWS Credentials CN
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region == 'cn-north-1' ||  matrix.region == 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_CN }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_CN }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+      - name: Configure AWS Credentials standard
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region != 'cn-north-1' &&  matrix.region != 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+
+      - name: Get git commit sha
+        run: |
+          echo "ADOT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          cd opentelemetry-lambda
+          echo "OTEL_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Set layer name
+        run: |
+          echo "OTEL_LAMBDA_LAYER=$LAYER-$OTEL_SHA-$ADOT_SHA" >> $GITHUB_ENV
+
+      - name: deploy layer
+        run: |
+          layerArn=$($UTILS/layer.sh -a)
+          echo $layerArn
+          if [[ $layerArn == "null" ]]; then
+            echo "building and deploying layer"
+            cd $LAYER_PATH
+            ./run.sh
+          else
+            echo "skip deploy layer"
+          fi
+          layerArn=$($UTILS/layer.sh -a)
+          echo $layerArn
+
+      - name: Checkout test framework
+        uses: actions/checkout@v2
+        if: ${{ success() }}
+        with:
+          repository: aws-observability/aws-otel-test-framework
+          path: test-framework
+
+      - name: Set sample stack name
+        run: |
+          echo "OTEL_LAMBDA_STACK=$STACK-$OTEL_SHA-$ADOT_SHA" >> $GITHUB_ENV
+
+      - name: deploy sample
+        continue-on-error: true
+        working-directory: opentelemetry-lambda/python/sample-xray
+        run: |
+          echo $OTEL_LAMBDA_STACK
+          ./run.sh
+
+      - name: validate sample
+        run: |
+          endpoint=$(${{ env.UTILS }}/endpoint.sh)
+          curl $endpoint
+          cp opentelemetry-lambda/python/sample-xray/test/expected.mustache test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cd test-framework
+          ./gradlew :validator:run  --args="-c default-lambda-validation.yml --endpoint $endpoint --region $AWS_REGION"
+
+      - name: install otel layer to sample
+        run: |
+          layerArn=$(${{ env.UTILS }}/layer.sh -a)
+          echo $layerArn
+          ${{ env.UTILS }}/update.sh -l $layerArn
+          ${{ env.UTILS }}/update.sh -e "Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/opt/collector-config/config.yaml,AWS_LAMBDA_EXEC_WRAPPER=/opt/python/otel-instrument}"
+
+      - name: validate layer
+        run: |
+          endpoint=$(${{ env.UTILS }}/endpoint.sh)
+          curl $endpoint
+          cp opentelemetry-lambda/python/sample-xray/test/expected.mustache test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cd test-framework
+          ./gradlew :validator:run  --args="-c default-lambda-validation.yml --endpoint $endpoint --region $AWS_REGION"
+
+      - name: clean sample
+        run: |
+          ${{ env.UTILS }}/clean.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,45 @@
+name: "Pull Request"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  AWS_REGION: us-east-1
+
+jobs:
+  PR-Python:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python: [3.8]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --recursive
+          cd opentelemetry-lambda
+          git fetch
+          git merge origin/master
+
+      - name: adot custom
+        run: |
+          cp -rf adot/* opentelemetry-lambda/
+
+      - name: Tox
+        working-directory: opentelemetry-lambda/python/src
+        run: |
+          pip install tox
+          tox
+      - name: build layer
+        working-directory: opentelemetry-lambda/python/src
+        run: ./run.sh -b
+
+      - name: build sample
+        working-directory: opentelemetry-lambda/python/sample-xray
+        run: ./run.sh -b

--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -1,0 +1,288 @@
+name: release-python
+env:
+  LAYER: py38-layer
+  STACK: py38-release
+  UTILS: ${{ github.workspace }}/opentelemetry-lambda/utils/sam
+
+on:
+  workflow_dispatch:
+    inputs:
+      fromLayer:
+        description: 'Soaked layer name in test account'
+        required: false
+        default: 'py38-layer-86558a5-2fc2419'
+      toLayer:
+        description: 'Layer name publishing to Prod account'
+        required: true
+        default: 'py38-preview'
+      version:
+        description: 'the version number to release'
+        required: true
+        default: '0.1'
+      regions:
+        description: 'regions to be deployed'
+        retuired: true
+        default: "{\"region\": [ \"us-east-1\", \"us-east-2\", \"us-west-1\", \"us-west-2\", \"ap-south-1\", \"ap-northeast-3\", \"ap-northeast-2\", \"ap-southeast-1\", \"ap-southeast-2\", \"ap-northeast-1\", \"ca-central-1\", \"eu-central-1\", \"eu-west-1\", \"eu-west-2\", \"eu-west-3\", \"eu-north-1\", \"sa-east-1\"]}"
+
+
+jobs:
+  cache-layer-from-test:
+    runs-on: ubuntu-latest
+
+    env:
+      KEY: ${{ github.event.inputs.fromLayer }}
+      AWS_REGION: us-west-2
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: adot custom
+        run: |
+          cp -rf adot/* opentelemetry-lambda/
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
+          mask-aws-account-id: false
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Cache layer
+        uses: actions/cache@v2
+        id: cache-layer
+        with:
+          path: ./layer.zip
+          key: ${{ github.event.inputs.fromLayer }}
+
+      - name: download layer
+        env:
+          OTEL_LAMBDA_LAYER: ${{ github.event.inputs.toLayer }}
+        run: |
+          layerArn=$($UTILS/layer.sh -a)
+          URL=$(aws lambda get-layer-version-by-arn --arn $layerArn --query Content.Location --output text)
+          curl $URL -o layer.zip
+
+  publish-layer:
+    needs: cache-layer-from-test
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{fromJson(github.event.inputs.regions)}}
+#        region-cn: [ cn-northeast-1, cn-north-1 ]
+#        region-optin: [ af-south-1, ap-east-1, eu-south-1, me-south-1 ]
+#        region: [ us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-3, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1]
+    env:
+      AWS_REGION: ${{matrix.region}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: adot custom
+        run: |
+          cp -rf adot/* opentelemetry-lambda/
+
+      - name: Configure AWS Credentials CN
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region == 'cn-north-1' ||  matrix.region == 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_CN }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_CN }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+      - name: Configure AWS Credentials standard
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region != 'cn-north-1' &&  matrix.region != 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+
+      - name: Cache layer
+        uses: actions/cache@v2
+        id: cache-layer
+        with:
+          path: ./layer.zip
+          key: ${{ github.event.inputs.fromLayer }}
+
+      - name: layer missing
+        if: steps.cache-layer.outputs.cache-hit != 'true'
+        run: |
+          exit 1
+
+      - name: clone
+        run: |
+          BUCKET_NAME="lambda-artifacts"-$(dd if=/dev/random bs=8 count=1 2>/dev/null | od -An -tx1 | tr -d ' \t\n')
+          aws s3 mb s3://$BUCKET_NAME
+          aws s3 cp layer.zip s3://$BUCKET_NAME
+          toLayerArn=$(aws lambda publish-layer-version --layer-name ${{ github.event.inputs.toLayer }} --content S3Bucket=$BUCKET_NAME,S3Key=layer.zip --query 'LayerVersionArn' --output text)
+          aws s3 rm s3://$BUCKET_NAME/layer.zip
+          aws s3 rb s3://$BUCKET_NAME
+          echo $toLayerArn
+
+      - name: public layer
+        continue-on-error: true
+        env:
+          OTEL_LAMBDA_LAYER: ${{ github.event.inputs.toLayer }}
+        run: |
+          layerVersion=$($UTILS/layer.sh -v)
+          echo $layerVersion
+          aws lambda add-layer-version-permission --layer-name ${{ github.event.inputs.toLayer }} --version-number $layerVersion --principal "*" --statement-id publish --action lambda:GetLayerVersion
+
+      - name: get layerARN
+        env:
+          OTEL_LAMBDA_LAYER: ${{ github.event.inputs.toLayer }}
+        if: ${{ success() }}
+        run: |
+          mkdir ${{ github.event.inputs.toLayer }}
+          $UTILS/layer.sh -a > ${{ github.event.inputs.toLayer }}/$AWS_REGION
+          cat ${{ github.event.inputs.toLayer }}/$AWS_REGION
+
+      - name: upload layer arn artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.inputs.toLayer }}
+          path: ${{ github.event.inputs.toLayer }}/${{matrix.region}}
+          retention-days: 15
+
+  smoke-test:
+    needs: publish-layer
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{fromJson(github.event.inputs.regions)}}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --recursive
+          cd opentelemetry-lambda
+          git fetch
+          git merge origin/master
+
+      - name: adot custom
+        run: |
+          cp -rf adot/* opentelemetry-lambda/
+
+      - name: Configure AWS Credentials CN
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region == 'cn-north-1' ||  matrix.region == 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_CN }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_CN }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+      - name: Configure AWS Credentials standard
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region != 'cn-north-1' &&  matrix.region != 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+
+      - name: Get git commit sha
+        run: |
+          echo "ADOT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          cd opentelemetry-lambda
+          echo "OTEL_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Set layer name
+        run: |
+          echo "OTEL_LAMBDA_LAYER=${{ github.event.inputs.toLayer }}" >> $GITHUB_ENV
+
+      - name: Checkout test framework
+        uses: actions/checkout@v2
+        if: ${{ success() }}
+        with:
+          repository: aws-observability/aws-otel-test-framework
+          path: test-framework
+
+      - name: Set sample stack name
+        run: |
+          echo "OTEL_LAMBDA_STACK=$STACK-$OTEL_SHA-$ADOT_SHA" >> $GITHUB_ENV
+
+      - name: deploy sample
+        continue-on-error: true
+        working-directory: opentelemetry-lambda/python/sample-xray
+        run: |
+          $UTILS/clean.sh
+          echo $OTEL_LAMBDA_STACK
+          ./run.sh
+
+      - name: validate sample
+        run: |
+          echo "Skip"
+
+      - name: download layerARNs
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.event.inputs.toLayer }}
+          path: ${{ github.event.inputs.toLayer }}
+
+      - name: install otel layer to sample
+        run: |
+          layerArn=$(cat ${{ github.event.inputs.toLayer }}/$AWS_REGION)
+          echo $layerArn
+          ${{ env.UTILS }}/update.sh -l $layerArn
+          ${{ env.UTILS }}/update.sh -e "Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/opt/collector-config/config.yaml,AWS_LAMBDA_EXEC_WRAPPER=/opt/python/otel-instrument}"
+
+      - name: validate layer
+        run: |
+          endpoint=$(${{ env.UTILS }}/endpoint.sh)
+          curl $endpoint
+          cp opentelemetry-lambda/python/sample-xray/test/expected.mustache test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cd test-framework
+          ./gradlew :validator:run  --args="-c default-lambda-validation.yml --endpoint $endpoint --region $AWS_REGION"
+
+      - name: clean sample
+        run: |
+          ${{ env.UTILS }}/clean.sh
+
+  release-to-github:
+    runs-on: ubuntu-latest
+    needs: [ smoke-test ]
+    steps:
+      - name: download layerARNs
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.event.inputs.toLayer }}
+          path: ${{ github.event.inputs.toLayer }}
+
+      - name: show layerARNs
+        run: |
+          for file in ${{ github.event.inputs.toLayer }}/*
+          do
+          echo $file
+          cat $file
+          done
+
+      - name: Generate release-note
+        run: |
+          echo "# ADOT Lambda Layer for Python 3.8" > release-note
+          echo "| Region | Layer ARN |" >> release-note
+          echo "|  ----  | ----  |" >> release-note
+          cd ${{ github.event.inputs.toLayer }}
+          for file in *
+          do
+          read arn < $file
+          echo "| " $file " | " $arn " |" >> ../release-note
+          done
+          cd ..
+          cat release-note
+
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          commitish: ${{ github.sha }}
+          release_name: Release ADOT Lambda layer for Python 3.8
+          body_path: release-note
+          draft: true
+          prerelease: true

--- a/.github/workflows/soak-py.yml
+++ b/.github/workflows/soak-py.yml
@@ -1,0 +1,153 @@
+name: soak-python
+
+env:
+  LAYER: py38-layer
+  LAYER_PATH: 'opentelemetry-lambda/python/src'
+  STACK: py38-soak
+  UTILS: ${{ github.workspace }}/opentelemetry-lambda/utils/sam
+
+on:
+  workflow_dispatch:
+    inputs:
+      runtime:
+        description: 'soaking'
+        required: false
+        default: 'Python3.8'
+      args:
+        description: 'soaking test args'
+        required: true
+        default: '600 5'
+  schedule:
+    - cron: '0 1 * * *' # every day
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        region: [ us-west-2 ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --recursive
+          cd opentelemetry-lambda
+          git fetch
+          git merge origin/master
+
+      - name: adot custom
+        run: |
+          cp -rf adot/* opentelemetry-lambda/
+
+      # set aws creds for CN regions and standard regions
+      - name: Configure AWS Credentials CN
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region == 'cn-north-1' ||  matrix.region == 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_CN }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_CN }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+      - name: Configure AWS Credentials standard
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ matrix.region != 'cn-north-1' &&  matrix.region != 'cn-northwest-1'}}
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST }}
+          mask-aws-account-id: false
+          aws-region: ${{matrix.region}}
+
+      - name: Get git commit sha
+        run: |
+          echo "ADOT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          cd opentelemetry-lambda
+          echo "OTEL_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Set layer name
+        run: |
+          echo "OTEL_LAMBDA_LAYER=$LAYER-$OTEL_SHA-$ADOT_SHA" >> $GITHUB_ENV
+
+      - name: deploy layer
+        run: |
+          layerArn=$(${{ env.UTILS }}/layer.sh -a)
+          echo $layerArn
+          if [[ $layerArn == "null" ]]; then
+            echo "building and deploying layer"
+            cd $LAYER_PATH
+            ./run.sh
+          else
+            echo "skip deploy layer"
+          fi
+          layerArn=$(${{ env.UTILS }}/layer.sh -a)
+          echo $layerArn
+
+      - name: Checkout test framework
+        uses: actions/checkout@v2
+        if: ${{ success() }}
+        with:
+          repository: aws-observability/aws-otel-test-framework
+          path: test-framework
+
+      - name: Set sample stack name
+        run: |
+          echo "OTEL_LAMBDA_STACK=$STACK-$OTEL_SHA-$ADOT_SHA" >> $GITHUB_ENV
+
+      - name: deploy sample
+        continue-on-error: true
+        working-directory: opentelemetry-lambda/python/sample-xray
+        run: |
+          echo $OTEL_LAMBDA_STACK
+          ./run.sh
+
+      - name: validate sample
+        run: |
+          echo "TODO"
+
+      - name: install otel layer to sample
+        run: |
+          layerArn=$(${{ env.UTILS }}/layer.sh -a)
+          echo $layerArn
+          ${{ env.UTILS }}/update.sh -l $layerArn
+          ${{ env.UTILS }}/update.sh -e "Variables={OPENTELEMETRY_COLLECTOR_CONFIG_FILE=/opt/collector-config/config.yaml,AWS_LAMBDA_EXEC_WRAPPER=/opt/python/otel-instrument}"
+
+      - name: validate layer
+        run: |
+          endpoint=$(${{ env.UTILS }}/endpoint.sh)
+          curl $endpoint
+          cp opentelemetry-lambda/python/sample-xray/test/expected.mustache test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cd test-framework
+          ./gradlew :validator:run  --args="-c default-lambda-validation.yml --endpoint $endpoint --region $AWS_REGION"
+
+      - name: Enable Lambda Insight
+        working-directory: ${{ env.UTILS }}
+        if: ${{ success() }}
+        run: |
+          ./update.sh -a "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:10"
+
+      - name: manually trigger soaking test
+        working-directory: ${{ env.UTILS }}
+        if: ${{ success() && github.event_name == 'workflow_dispatch' }}
+        run: |
+          pip install boto3
+          functionName=$(./function.sh)
+          endpoint=$(./endpoint.sh)
+          python3 ./soak.py $functionName ${{ github.event.inputs.args }} $endpoint
+          echo "Soaking test done."
+
+      - name: scheduled soaking test
+        working-directory: ${{ env.UTILS }}
+        if: ${{ success() && github.event_name != 'workflow_dispatch' }}
+        run: |
+          pip install boto3
+          functionName=$($UTILS/function.sh)
+          endpoint=$($UTILS/endpoint.sh)
+          python3 soak.py $functionName 1800 5 $endpoint
+          echo "Soaking test done."
+
+      - name: clean sample
+        run: |
+          ${{ env.UTILS }}/clean.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "opentelemetry-lambda"]
+	path = opentelemetry-lambda
+	url = https://github.com/open-telemetry/opentelemetry-lambda.git

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+
+## Reporting Bugs/Feature Requests
+
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+
+When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
+reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made relevant to the bug
+* Anything unusual about your environment or deployment
+
+
+## Contributing via Pull Requests
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+1. You are working against the latest source on the *main* branch.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+
+To send us a pull request, please:
+
+1. Fork the repository.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+3. Ensure local tests pass.
+4. Commit to your fork using clear commit messages.
+5. Send us a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+
+## Finding contributions to work on
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
+
+
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.
+
+
+## Security issue notifications
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+
+
+## Licensing
+
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# AWS Distro for OpenTelemetry support for AWS Lambda in Python
+
+As an event-driven, serverless computing platform, AWS Lambda runs user's code —knowns as **Lambda function**— in sandbox environment. So, launching OpenTelemetry Collector in Lambda environment needs the help of [AWS Lambda Extensions](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-extensions-in-preview/). This project provides ADOT Lambda layers user can use directly. The layers embed both ADOT Collector(as a Lambda extension) and SDK, Lambda user can onboard OpenTelemetry with this solution out-of-the-box.
+
+[OpenTelemetry Python3.8 Lambda with sample](sample-apps/python-lambda/README.md) (Both SDK and Collector)
+
+[OpenTelemetry Lambda layer](extensions/aoc-extension//README.md) (Collector only)
+
+
+## Security
+
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This project is licensed under the Apache-2.0 License.

--- a/adot/collector/config.yaml
+++ b/adot/collector/config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  logging:
+    loglevel: debug
+  awsxray:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging, awsxray]
+    metrics:
+      receivers: [otlp]
+      exporters: [logging]

--- a/adot/collector/go.mod
+++ b/adot/collector/go.mod
@@ -1,0 +1,16 @@
+module github.com/open-telemetry/opentelemetry-lambda/collector
+
+go 1.16
+
+replace (
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws => github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws v0.23.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray => github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.23.0
+	github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents => ./lambdacomponents
+)
+
+require (
+	github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents v0.0.0
+	github.com/spf13/cobra v1.1.3
+	github.com/spf13/viper v1.7.1
+	go.opentelemetry.io/collector v0.23.0
+)

--- a/adot/collector/lambdacomponents/default.go
+++ b/adot/collector/lambdacomponents/default.go
@@ -1,0 +1,46 @@
+package lambdacomponents
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/loggingexporter"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/exporter/prometheusexporter"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+)
+
+func Components() (
+	component.Factories,
+	error,
+) {
+	var errs []error
+
+	receivers, err := component.MakeReceiverFactoryMap(
+		otlpreceiver.NewFactory(),
+	)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	exporters, err := component.MakeExporterFactoryMap(
+		awsxrayexporter.NewFactory(),
+		awsemfexporter.NewFactory(),
+		prometheusexporter.NewFactory(),
+		loggingexporter.NewFactory(),
+		otlpexporter.NewFactory(),
+		otlphttpexporter.NewFactory(),
+	)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	factories := component.Factories{
+		Receivers: receivers,
+		Exporters: exporters,
+	}
+
+	return factories, consumererror.CombineErrors(errs)
+}

--- a/adot/collector/lambdacomponents/go.mod
+++ b/adot/collector/lambdacomponents/go.mod
@@ -1,0 +1,14 @@
+module github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents
+
+go 1.16
+
+replace (
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws => github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws v0.23.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray => github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.23.0
+)
+
+require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.23.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.23.0
+	go.opentelemetry.io/collector v0.23.0
+)

--- a/adot/python/release-note.md
+++ b/adot/python/release-note.md
@@ -1,0 +1,20 @@
+# ADOT Lambda Layer for Python 3.8
+| Region | Layer ARN |
+|  ----  | ----  |
+|  ap-northeast-1  |  arn:aws:lambda:ap-northeast-1:611364707713:layer:py38-preview:7  |
+|  ap-northeast-2  |  arn:aws:lambda:ap-northeast-2:611364707713:layer:py38-preview:7  |
+|  ap-northeast-3  |  arn:aws:lambda:ap-northeast-3:611364707713:layer:py38-preview:7  |
+|  ap-south-1  |  arn:aws:lambda:ap-south-1:611364707713:layer:py38-preview:7  |
+|  ap-southeast-1  |  arn:aws:lambda:ap-southeast-1:611364707713:layer:py38-preview:7  |
+|  ap-southeast-2  |  arn:aws:lambda:ap-southeast-2:611364707713:layer:py38-preview:7  |
+|  ca-central-1  |  arn:aws:lambda:ca-central-1:611364707713:layer:py38-preview:7  |
+|  eu-central-1  |  arn:aws:lambda:eu-central-1:611364707713:layer:py38-preview:7  |
+|  eu-north-1  |  arn:aws:lambda:eu-north-1:611364707713:layer:py38-preview:7  |
+|  eu-west-1  |  arn:aws:lambda:eu-west-1:611364707713:layer:py38-preview:7  |
+|  eu-west-2  |  arn:aws:lambda:eu-west-2:611364707713:layer:py38-preview:7  |
+|  eu-west-3  |  arn:aws:lambda:eu-west-3:611364707713:layer:py38-preview:7  |
+|  sa-east-1  |  arn:aws:lambda:sa-east-1:611364707713:layer:py38-preview:7  |
+|  us-east-1  |  arn:aws:lambda:us-east-1:611364707713:layer:py38-preview:7  |
+|  us-east-2  |  arn:aws:lambda:us-east-2:611364707713:layer:py38-preview:7  |
+|  us-west-1  |  arn:aws:lambda:us-west-1:611364707713:layer:py38-preview:7  |
+|  us-west-2  |  arn:aws:lambda:us-west-2:611364707713:layer:py38-preview:7  |

--- a/adot/python/sample-xray/function/lambda_function.py
+++ b/adot/python/sample-xray/function/lambda_function.py
@@ -1,0 +1,28 @@
+import os
+import json
+import aiohttp
+import asyncio
+import boto3
+
+
+async def fetch(session, url):
+    async with session.get(url) as response:
+        return await response.text()
+
+
+async def callAioHttp():
+    async with aiohttp.ClientSession() as session:
+        html = await fetch(session, "http://httpbin.org/")
+
+s3 = boto3.resource("s3")
+
+# lambda function
+def lambda_handler(event, context):
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(callAioHttp())
+
+    for bucket in s3.buckets.all():
+        print(bucket.name)
+
+    return {"statusCode": 200, "body": json.dumps(os.environ.get("_X_AMZN_TRACE_ID"))}

--- a/adot/python/sample-xray/function/requirements.txt
+++ b/adot/python/sample-xray/function/requirements.txt
@@ -1,0 +1,1 @@
+aiohttp

--- a/adot/python/sample-xray/run.sh
+++ b/adot/python/sample-xray/run.sh
@@ -1,0 +1,3 @@
+stack=${OTEL_LAMBDA_STACK-"otel-stack"}
+sam build -u
+sam deploy --stack-name $stack --capabilities CAPABILITY_NAMED_IAM --resolve-s3

--- a/adot/python/sample-xray/template.yml
+++ b/adot/python/sample-xray/template.yml
@@ -1,0 +1,73 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: OpenTelemetry Python Lambda layer for Python 3.8 Runtime
+Mappings:
+  RegionMap:
+    us-east-1:
+      value: "arn:aws:lambda:us-east-1:611364707713:layer:py38-preview:5"
+    us-east-2:
+      value: "arn:aws:lambda:us-east-2:611364707713:layer:py38-preview:5"
+    us-west-1:
+      value: "arn:aws:lambda:us-west-1:611364707713:layer:py38-preview:5"
+    us-west-2:
+      value: "arn:aws:lambda:us-west-2:611364707713:layer:py38-preview:5"
+    ap-south-1:
+      value: "arn:aws:lambda:ap-south-1:611364707713:layer:py38-preview:5"
+    ap-northeast-3:
+      value: "arn:aws:lambda:ap-northeast-3:611364707713:layer:py38-preview:5"
+    ap-northeast-2:
+      value: "arn:aws:lambda:ap-northeast-2:611364707713:layer:py38-preview:5"
+    ap-southeast-1:
+      value: "arn:aws:lambda:ap-southeast-1:611364707713:layer:py38-preview:5"
+    ap-southeast-2:
+      value: "arn:aws:lambda:ap-southeast-2:611364707713:layer:py38-preview:5"
+    ap-northeast-1:
+      value: "arn:aws:lambda:ap-northeast-1:611364707713:layer:py38-preview:5"
+    ca-central-1:
+      value: "arn:aws:lambda:ca-central-1:611364707713:layer:py38-preview:5"
+    eu-central-1:
+      value: "arn:aws:lambda:eu-central-1:611364707713:layer:py38-preview:5"
+    eu-west-1:
+      value: "arn:aws:lambda:eu-west-1:611364707713:layer:py38-preview:5"
+    eu-west-2:
+      value: "arn:aws:lambda:eu-west-2:611364707713:layer:py38-preview:5"
+    eu-west-3:
+      value: "arn:aws:lambda:eu-west-3:611364707713:layer:py38-preview:5"
+    eu-north-1:
+      value: "arn:aws:lambda:eu-north-1:611364707713:layer:py38-preview:5"
+    sa-east-1:
+      value: "arn:aws:lambda:sa-east-1:611364707713:layer:py38-preview:5"
+Resources:
+  api:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: api
+      TracingEnabled: true
+      OpenApiVersion: 3.0.2
+  function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: lambda_function.lambda_handler
+      Runtime: python3.8
+      CodeUri: ./function
+      Description: OTel Python Lambda dry Sample
+      MemorySize: 512
+      Timeout: 15
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - AWSLambda_ReadOnlyAccess
+        - AWSXrayWriteOnlyAccess
+        - AmazonS3FullAccess
+      Tracing: Active
+      Environment:
+        Variables:
+          AWS_LAMBDA_EXEC_WRAPPER: /opt/python/otel-instrument
+      Layers:
+        - !FindInMap [RegionMap, !Ref "AWS::Region", value]
+      Events:
+        getEndpoint:
+          Type: Api
+          Properties:
+            RestApiId: !Ref api
+            Path: /
+            Method: GET

--- a/adot/python/sample-xray/test/expected.mustache
+++ b/adot/python/sample-xray/test/expected.mustache
@@ -1,0 +1,60 @@
+ [{
+     "origin":"AWS::ApiGateway::Stage",
+     "subsegments":[
+         {
+             "name":"Lambda",
+             "namespace":"aws"
+         }
+     ]
+ },
+{
+    "name":"py38-.*",
+    "http":{
+        "response":{
+            "status":200
+        }
+    },
+    "origin":"AWS::Lambda"
+},
+{
+    "name":"py38-.*",
+    "origin":"AWS::Lambda::Function",
+    "subsegments":[
+        {
+            "name":"Invocation",
+                         "subsegments":[
+                             {
+                                 "name":"lambda_function\\.lambda_handler",
+                                 "aws":{
+                                     "xray":{
+                                         "auto_instrumentation":false,
+                                         "sdk":"opentelemetry for python"
+                                     }
+                                 }
+                             }
+                         ]
+        },
+        {
+            "name":"Overhead"
+        }
+    ]
+
+},
+{
+    "name":"HTTP GET",
+    "inferred":true,
+    "http":{
+        "request":{
+            "url":"http://httpbin\\.org/",
+            "method":"GET"
+        }
+    }
+},
+{
+    "name":"S3",
+    "origin":"AWS::S3",
+    "inferred":true,
+    "aws":{
+        "operation":"ListBuckets"
+    }
+}]

--- a/adot/utils/sam/clean.sh
+++ b/adot/utils/sam/clean.sh
@@ -1,0 +1,4 @@
+stack=${OTEL_LAMBDA_STACK-"otel-stack"}
+
+aws cloudformation delete-stack --stack-name $stack || true
+aws cloudformation wait stack-delete-complete --stack-name $stack || true

--- a/adot/utils/sam/cleanStacks.sh
+++ b/adot/utils/sam/cleanStacks.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -u
+
+region=${AWS_REGION-$(aws configure get region)}
+stacks=$(aws cloudformation list-stacks --region $region --query 'StackSummaries[*].StackName' --output text)
+
+echo $stacks
+for stack in $stacks
+do
+    echo $stack
+    if [[ $stack == $1 ]]; then
+        echo "clean stack ..."
+        $(aws cloudformation delete-stack --stack-name $stack --region $region)
+    fi
+done

--- a/adot/utils/sam/endpoint.sh
+++ b/adot/utils/sam/endpoint.sh
@@ -1,0 +1,5 @@
+stack=${OTEL_LAMBDA_STACK-"otel-stack"}
+region=${AWS_REGION-$(aws configure get region)}
+
+apiid=$(aws cloudformation describe-stack-resource --stack-name $stack --logical-resource-id api --query 'StackResourceDetail.PhysicalResourceId' --output text)
+echo https://$apiid.execute-api.$region.amazonaws.com/api/

--- a/adot/utils/sam/function.sh
+++ b/adot/utils/sam/function.sh
@@ -1,0 +1,4 @@
+stack=${OTEL_LAMBDA_STACK-"sample"}
+
+functionName=$(aws cloudformation describe-stack-resource --stack-name $stack --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
+echo $functionName

--- a/adot/utils/sam/layer.sh
+++ b/adot/utils/sam/layer.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+set -u
+
+main () {
+    saved_args="$@"
+    # layerName can be layer name or layer arn without version
+    layerName=${OTEL_LAMBDA_LAYER-"otel-layer"}
+    layerArn=false
+    layerVersion=false
+    region=${AWS_REGION-$(aws configure get region)}
+
+    while getopts "avn:r:" opt; do
+        case "${opt}" in
+            h) echo_usage
+                exit 0
+                ;;
+            r) region="${OPTARG}"
+                ;;
+            n) layerName="${OPTARG}"
+                ;;
+            a) layerArn=true
+                ;;
+            v) layerVersion=true
+                ;;
+            \?) echo "Invalid option: -${OPTARG}" >&2
+                exit 1
+                ;;
+            :)  echo "Option -${OPTARG} requires an argument" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [[ $layerArn == true ]]; then
+        # CLI --output text bug
+        arn=$(aws lambda list-layer-versions --layer-name $layerName --query 'max_by(LayerVersions, &Version).LayerVersionArn')
+        echo $arn|sed 's/\"//g'
+    fi
+
+    if [[ $layerVersion == true ]]; then
+        aws lambda list-layer-versions --layer-name $layerName --query 'max_by(LayerVersions, &Version).Version'
+    fi
+}
+
+main "$@"
+

--- a/adot/utils/sam/soak.py
+++ b/adot/utils/sam/soak.py
@@ -1,0 +1,109 @@
+import boto3
+from threading import Thread
+import os
+import sys
+import time
+
+# sign of Alarm, False means no Alarm
+state = False
+
+
+def invoke_lambda(interval, endpoint):
+    while True:
+        os.system("curl " + endpoint)
+        time.sleep(interval)
+    
+
+def alarm_puller(function_name):
+    global state
+
+    # Memory alarm
+    cloudwatch.put_metric_alarm(
+        AlarmName=memory_alarm,
+        ActionsEnabled=True, OKActions=[], AlarmActions=[], InsufficientDataActions=[],
+        MetricName='memory_utilization',
+        Namespace='LambdaInsights',
+        Statistic='Maximum',
+        Dimensions=[
+            {
+                'Name': 'function_name',
+                'Value': function_name
+            },
+        ],
+        Period=60,
+        EvaluationPeriods=5,
+        DatapointsToAlarm=5,
+        Threshold=45,
+        ComparisonOperator='GreaterThanThreshold',
+        TreatMissingData='notBreaching'
+    )
+
+    # CPU alarm
+    cloudwatch.put_metric_alarm(
+        AlarmName=cpu_alarm,
+        ActionsEnabled=True, OKActions=[], AlarmActions=[], InsufficientDataActions=[],
+        MetricName='cpu_total_time',
+        Namespace='LambdaInsights',
+        Statistic='Maximum',
+        Dimensions=[
+            {
+                'Name': 'function_name',
+                'Value': function_name
+            },
+        ],
+        Period=60,
+        EvaluationPeriods=5,
+        DatapointsToAlarm=5,
+        Threshold=150,
+        ComparisonOperator='GreaterThanThreshold',
+        TreatMissingData='notBreaching'
+    )
+
+    paginator = cloudwatch.get_paginator('describe_alarms')
+
+    while True:
+        for response in paginator.paginate(AlarmNames=[memory_alarm, cpu_alarm]):
+            for alarm in response['MetricAlarms']:
+                print('{} state {}'.format(alarm['AlarmName'], alarm['StateValue']))
+                if alarm['StateValue'] == 'ALARM':
+                    state = True
+                    return
+        
+        time.sleep(60)
+
+if __name__ == '__main__':
+
+    name = sys.argv[1]
+    print(name)
+
+    soaking_time = int(sys.argv[2])
+    print(soaking_time)
+
+    emitter_interval = int(sys.argv[3])
+    print(emitter_interval)
+
+    endpoint = sys.argv[4]
+    print(endpoint)
+
+    # alarms
+    memory_alarm='otel_lambda_memory-'+name
+    cpu_alarm='otel_lambda_cpu-'+name
+
+    cloudwatch = boto3.client('cloudwatch')
+
+    # emitter thread
+    Thread(target=invoke_lambda, name='emitter', args=(emitter_interval, endpoint,), daemon=True).start()
+    
+    alarm_thread = Thread(target=alarm_puller, name='alarm_puller', args=(name,), daemon=True)
+    alarm_thread.start()
+    alarm_thread.join(soaking_time)
+
+    # if alarm
+    if state:
+        print('Soaking test failed!')
+        exit(1)
+    else:
+        print('Soaking test succeed!')
+        # If no problem, delete alarm
+        cloudwatch.delete_alarms(AlarmNames=[memory_alarm, cpu_alarm])
+        exit(0)

--- a/adot/utils/sam/update.sh
+++ b/adot/utils/sam/update.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+set -u
+
+stack=${OTEL_LAMBDA_STACK-"otel-stack"}
+region=${AWS_REGION-$(aws configure get region)}
+environment=''
+layers=''
+appendLayers=''
+
+while getopts "r:s:l:e:a:" opt; do
+    case "${opt}" in
+        r) region="${OPTARG}"
+            ;;
+        s) stack="${OPTARG}"
+            ;;
+        l) layers="${OPTARG}"
+            ;;
+        e) environment="${OPTARG}"
+            ;;
+        a) appendLayers="${OPTARG}"
+            ;;
+        \?) echo "Invalid option: -${OPTARG}" >&2
+            exit 1
+            ;;
+        :)  echo "Option -${OPTARG} requires an argument" >&2
+            exit 1
+            ;;
+    esac
+done
+
+function=$(aws cloudformation describe-stack-resource --stack-name $stack --region $region --logical-resource-id function --query 'StackResourceDetail.PhysicalResourceId' --output text)
+echo $function
+
+params=''
+if [[ -n $layers ]]; then
+    params=' --layers '$layers
+fi
+
+if [[ -n $appendLayers ]]; then
+    params=' --layers '$(./layer.sh -a)' '$appendLayers
+fi
+
+if [[ -n $environment ]]; then
+    params=$params' --environment '$environment
+fi
+
+echo $params
+
+aws lambda update-function-configuration --function-name $function --region $region $params


### PR DESCRIPTION
**Description:** 
This PR is for ADOT Lambda internal review:
1. add opentelemetry-lambda as submodule
2. create folder `adot` for aws custom logic, here just give a simple example by overwriting upstream files. Will add more details like `sed`, `go edit mod replace` in next PR. 
3. AWS sample applications are in `adot` folder, follows the same structure as upstream.
4. CI/CD downloads submodule, then add `adot` on it.
5. give an example of release-note in `adot/python/release-note.md`
6. contains 5 workflows for python: PR, integration, soak, release, canary.
7. CI/CD now only covers 17 regions. NOT includes 2 CN regions and 4 Opt-In regions.

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
