### PR TITLE
adjust soak and canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -2,7 +2,7 @@ name: Canary (published artifacts) build
 
 on:
   schedule:
-    - cron: '25 * * * *' # hourly job
+    - cron: '25 */8 * * *' # every 8 hours
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -2,7 +2,7 @@ name: Soak tests
 
 on:
   schedule:
-    - cron: '* 1 * * *' # daily job
+    - cron: '0 14 * * 1,3,5' # Mon, Wed, Fri morning PST
   workflow_dispatch:
     inputs:
       soak_config:

--- a/adot/utils/soak/soak.py
+++ b/adot/utils/soak/soak.py
@@ -49,7 +49,7 @@ def enableLambdaInsight(function_name):
 
 def parse_args():
     # default setting
-    _soaking_time, _emitter_interval, _cpu_threshold, _memory_threshold = 600, 5, 60, 45
+    _soaking_time, _emitter_interval, _cpu_threshold, _memory_threshold = 10000, 5, 60, 45
     argument_list = sys.argv[1:]
     short_options = "i:t:e:n:c:m:"
     long_options = [


### PR DESCRIPTION
The current soak and canary frequency is high for baking, Now the functionality is stable, will
decrease soak and canary frequency.
increase soak time to 3 hours.