### PR TITLE
Support multiple propagators for Python Lambda Layer

### DIFF
--- a/adot/python/src/otel/otel_sdk/otel-instrument
+++ b/adot/python/src/otel/otel_sdk/otel-instrument
@@ -41,7 +41,11 @@ environ["OTEL_RESOURCE_ATTRIBUTES"] = "%s,%s" % (
 )
 
 # xray propagator
-environ["OTEL_PROPAGATORS"] = "aws_xray"
+configured_propagators = environ.get("OTEL_PROPAGATORS")
+if not configured_propagators:
+    environ["OTEL_PROPAGATORS"] = "aws_xray"
+elif "aws_xray" not in configured_propagators.split(","):
+    environ["OTEL_PROPAGATORS"] = ",".join([configured_propagators, "aws_xray"])
 
 # start the runtime with the extra options
 system(" ".join(args))

--- a/adot/python/src/template.yml
+++ b/adot/python/src/template.yml
@@ -38,6 +38,7 @@ Resources:
       Environment:
         Variables:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/python/otel-instrument
+          OTEL_PROPAGATORS: aws_xray
       Tracing: Active
       Layers:
         - !Ref OTelLayer

--- a/sample-apps/python-aws-sdk-aiohttp-sam/template.yml
+++ b/sample-apps/python-aws-sdk-aiohttp-sam/template.yml
@@ -23,6 +23,7 @@ Resources:
       Environment:
         Variables:
           AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+          OTEL_PROPAGATORS: aws_xray
       Tracing: Active
       Layers:
         - !FindInMap [RegionMap, !Ref "AWS::Region", layer]


### PR DESCRIPTION
**Description:**

With the current Python Lambda layer, we override the `OTEL_PROPAGATORS` environment variable and set it to be `aws_xray` which does not allow users to set other propagators.

This PR fixes that by checking to see if `aws_xray` is set and only overriding if the environment variable is empty. Since this is meant as an AWS distribution, it will automatically add `aws_xray` as a propagator if it is not present in the existing truthy `OTEL_PROPAGATORS` variable so users don't have to think twice about adding it.

Additionally, we added `OTEL_PROPAGATORS: aws_xray` to the environment variables set in the sample apps/terraform just to make it explicit that this can be configured by users.

Fixes: #109

**Testing:**

Printing out the `OTEL_PROPAGATORS` variable in the `lambda_handler` returns the console set environment variables + `aws_xray` if it is missing.

**Documentation:**

No documentation added.
