### PR TITLE
Update nodejs wrapper files for v0.23.0

### DIFF
--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -37,11 +37,11 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.0.0-rc.0",
-    "@opentelemetry/core": "^0.19.0",
-    "@opentelemetry/id-generator-aws-xray": "^0.16.0",
-    "@opentelemetry/node": "^0.19.0",
-    "@opentelemetry/propagator-aws-xray": "^0.16.0",
-    "@opentelemetry/propagator-b3": "^0.19.0"
+    "@opentelemetry/api": "1.0.1",
+    "@opentelemetry/core": "^0.23.0",
+    "@opentelemetry/id-generator-aws-xray": "^0.23.0",
+    "@opentelemetry/node": "^0.23.0",
+    "@opentelemetry/propagator-aws-xray": "^0.23.0",
+    "@opentelemetry/propagator-b3": "^0.23.0"
   }
 }

--- a/nodejs/wrapper-adot/src/adot-extension.ts
+++ b/nodejs/wrapper-adot/src/adot-extension.ts
@@ -1,5 +1,5 @@
 import { propagation } from '@opentelemetry/api';
-import { CompositePropagator, HttpTraceContext } from '@opentelemetry/core';
+import { CompositePropagator, HttpTraceContextPropagator } from '@opentelemetry/core';
 import { NodeTracerConfig } from '@opentelemetry/node';
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { AWSXRayIdGenerator } from '@opentelemetry/id-generator-aws-xray';
@@ -14,7 +14,7 @@ if (!process.env.OTEL_PROPAGATORS) {
     new CompositePropagator({
       propagators: [
         new AWSXRayPropagator(),
-        new HttpTraceContext(),
+        new HttpTraceContextPropagator(),
         new B3Propagator(),
         new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
       ],


### PR DESCRIPTION
**Description:**

As upstream goes to `v0.23.0`, we need to update our downstream files.

Upstream's PR: https://github.com/open-telemetry/opentelemetry-lambda/pull/112

**Link to tracking Issue:**

N/A

**Testing:**

Traces still appear in Lambda and manually when using `curl -sS`.

**Documentation:**

N/A
