### PR TITLE
Use v0.11.0 ADOT collector Lambda components

### DIFF
--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -1,8 +1,8 @@
 cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 # replace collector with AOC
-go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.10.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.27.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.27.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.27.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.11.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.29.1-0.20210630203112-81d57601b1bc
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.29.1-0.20210630203112-81d57601b1bc
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.29.1-0.20210630203112-81d57601b1bc
 go mod tidy


### PR DESCRIPTION
**Description:**

Now that the AWS OTel Collector (AOC) has updated the components used by the Lambda Layer Collector extensions, we can update our `./patch-upstream.sh` to make sure we replace with the latest version.

See [AOC LambdaComponents v0.11.0 release](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)

- [x] "TODO" Additionally, we bump the **upstream reference** to the latest apps which are compatible with this new AOC.

**Link to tracking Issue:**

N/A

**Testing:**

**NOTE:** Should be merged _after_ all the sample apps have been updated upstream and confirmed to be working with the latest collector.

DO NOT MERGE PR until this PR updates the `opentelemetry-lambda` submodule reference to the latest validated one.

**Documentation:**

N/A
