### PR TITLE
Update Docs for Python38/Nodejs/JavaWrapper/JavaAgent/Collector Lambd…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2021-07-08 Release
+- Python3.8 layer **aws-otel-python38-ver-1-3-0** contains OpenTelemetry Python `v1.3.0` with Contrib `v0.22b0`
+- Nodejs layer **aws-otel-nodejs-ver-0-23-0** contains OpenTelemetry JavaScript `v0.23.0` with Contrib `v0.23.0`
+- Java-Wrapper layer **aws-otel-java-wrapper-ver-1-2-0** contains OpenTelemetry Java `v1.2.0`
+- Java-Agent layer **aws-otel-java-agent-ver-1-2-0** contains AWS OpenTelemetry Java instrumentation `v1.2.0`
+- Collector layer **aws-otel-collector-ver-0-29-1** contains ADOT Collector for Lambda `v0.11.0`
+- Layers are bundled with OpenTelemetry Collector extension with [reduced AWS OpenTelemetry Collector v0.11.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.11.0)
+- Layers cover 16 AWS Regions: us-east-1, us-east-2, us-west-1, us-west-2, ap-south-1, ap-northeast-2, ap-southeast-1, ap-southeast-2, ap-northeast-1, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, eu-north-1, sa-east-1
+- Layers are built from Git commit `f5974978a38f4b67cf088d38f3047aadef6b61d0` at https://github.com/aws-observability/aws-otel-lambda/commit/f5974978a38f4b67cf088d38f3047aadef6b61d0
+
 ## 2021-05-26 Release
 - Python3.8 layer **aws-otel-python38-ver-1-2-0** contains OpenTelemetry Python `v1.2.0` with Contrib `v0.21b0`
 - Nodejs layer **aws-otel-nodejs-ver-0-19-0** contains OpenTelemetry JavaScript `v0.19.0` with Contrib `v0.16.0`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AWS managed OpenTelemetry Lambda Layers
 
 As a downstream Repo of [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda), ___aws-otel-lambda___ publishes AWS managed OpenTelemetry Lambda layers that are preconfigured for use with AWS services and bundle the reduced AWS Collector. Users can onboard to OpenTelemetry in their existing Lambda functions by adding these ready-made layers directly.
-- Python3.8 layer [aws-otel-python38-ver-1-2-0](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.2.0` with Contrib `v0.21b0`
-- Nodejs layer [aws-otel-nodejs-ver-0-19-0](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript `v0.19.0` with Contrib `v0.16.0`
+- Python3.8 layer [aws-otel-python38-ver-1-3-0](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.3.0` with Contrib `v0.22b0`
+- Nodejs layer [aws-otel-nodejs-ver-0-23-0](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js) contains OpenTelemetry JavaScript `v0.23.0` with Contrib `v0.23.0`
 - Java-Wrapper layer [aws-otel-java-wrapper-ver-1-2-0](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java) contains OpenTelemetry Java `v1.2.0`
 - Java-Agent layer [aws-otel-java-agent-ver-1-2-0](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java-auto-instr) contains AWS OpenTelemetry Java instrumentation `v1.2.0`
-- Collector layer [aws-otel-collector-ver-0-27-0](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) contains ADOT Collector for Lambda `v0.10.0`
+- Collector layer [aws-otel-collector-ver-0-29-1](https://aws-otel.github.io/docs/getting-started/lambda/lambda-dotnet) contains ADOT Collector for Lambda `v0.11.0`
 
 
 


### PR DESCRIPTION
**Description:**

With the successful deploy of new Lambda Layers for several SDKs, we update our downstream repo Docs and Changelog for historical reference.

The updates to follow upstream on these updates:
* Python SDK Core `1.3.0` and Contrib `0.22b0`
* NodeJS SDK Core `0.23.0` and Contrib `0.23.0`
* ADOT collector `0.29.1`

**Link to tracking Issue:**

N/A

**Testing:**

N/A

**Documentation:**

- Update README.md
- Update CHANGELOG.md
