### PR TITLE
Update Terraform configurations and CI workflows to test Java AWS SDK Agent Sample Application is emitting metrics to AMP

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,7 +28,9 @@ jobs:
             build_directory: java
             build_command: ./build.sh
             terraform_directory: sample-apps/java-agent-aws-sdk-terraform
-            expected_template: adot/utils/expected-templates/java-awssdk-agent.json
+            amp_regions: [ "us-west-2", "us-east-1", "us-east-2", "eu-central-1", "eu-west-1"]
+            expected_trace_template: adot/utils/expected-templates/java-awssdk-agent.json
+            expected_metric_template: adot/utils/expected-templates/java-awssdk-agent-metric.json
           - name: java-awssdk-wrapper
             language: java
             build_directory: java
@@ -141,6 +143,11 @@ jobs:
         id: extract-endpoint
         run: terraform output -raw api-gateway-url
         working-directory: ${{ matrix.terraform_directory }}
+      - name: Extract AMP endpoint
+        if: ${{ matrix.name == 'java-awssdk-agent' && contains(matrix.amp_regions, matrix.aws_region)}}
+        id: extract-amp-endpoint
+        run: terraform output -raw amp_endpoint
+        working-directory: ${{ matrix.terraform_directory }}
       - name: Send request to endpoint
         run: curl -sS ${{ steps.extract-endpoint.outputs.stdout }}
       - name: Checkout test framework
@@ -148,7 +155,7 @@ jobs:
         with:
           repository: aws-observability/aws-otel-test-framework
           path: test-framework
-      - name: validate sample
+      - name: validate trace sample
         uses: nick-invision/retry@v2
         with:
           timeout_seconds: 300
@@ -157,7 +164,15 @@ jobs:
             cp ${{ matrix.expected_template }} test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
             cd test-framework
             ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
+      # add back in once the java-agent layer is published and the ARNs are available
+      # - name: validate java agent metric sample
+      #   if: ${{ matrix.name == 'java-awssdk-agent' && contains(matrix.amp_regions, matrix.aws_region)}}
+      #   run: |
+      #     cp ${{ matrix.expected_metric_template }} test-framework/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+      #     cd test-framework
+      #     ./gradlew :validator:run --args="-c prometheus-static-metric-validation.yml --cortex-instance-endpoint ${{ steps.extract-amp-endpoint.outputs.stdout }} --region $AWS_REGION"
       - name: Destroy terraform
         if: always()
         run: terraform destroy -auto-approve
         working-directory: ${{ matrix.terraform_directory }}
+  

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -18,37 +18,38 @@ jobs:
             build_directory: java
             build_command: ./build.sh
             terraform_directory: integration-tests/java/aws-sdk/agent
-            expected_template: adot/utils/expected-templates/java-awssdk-agent.json
+            expected_trace_template: adot/utils/expected-templates/java-awssdk-agent.json
+            expected_metric_template: adot/utils/expected-templates/java-awssdk-agent-metric.json
           - name: java-awssdk-wrapper
             language: java
             build_directory: java
             build_command: ./build.sh
             terraform_directory: integration-tests/java/aws-sdk/wrapper
-            expected_template: adot/utils/expected-templates/java-awssdk-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/java-awssdk-wrapper.json
           - name: java-okhttp-wrapper
             language: java
             build_directory: java
             build_command: ./build.sh
             terraform_directory: integration-tests/java/okhttp/wrapper
-            expected_template: adot/utils/expected-templates/java-okhttp-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/java-okhttp-wrapper.json
           - name: nodejs-awssdk
             language: nodejs
             build_directory: nodejs
             build_command: ./build.sh
             terraform_directory: integration-tests/nodejs/aws-sdk
-            expected_template: adot/utils/expected-templates/nodejs-awssdk.json
+            expected_trace_template: adot/utils/expected-templates/nodejs-awssdk.json
           - name: python
             language: python
             build_directory: python
             build_command: ./build.sh
             terraform_directory: integration-tests/python/aws-sdk
-            expected_template: adot/utils/expected-templates/python.json
+            expected_trace_template: adot/utils/expected-templates/python.json
           - name: dotnet-awssdk-wrapper
             language: dotnet
             build_directory: dotnet
             build_command: ./build.sh
             terraform_directory: integration-tests/dotnet/aws-sdk/wrapper
-            expected_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
     steps:
       - uses: actions/checkout@v2
         with:
@@ -135,6 +136,11 @@ jobs:
         id: extract-endpoint
         run: terraform output -raw api-gateway-url
         working-directory: ${{ matrix.terraform_directory }}
+      - name: Extract AMP endpoint
+        id: extract-amp-endpoint
+        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        run: terraform output -raw amp_endpoint
+        working-directory: ${{ matrix.terraform_directory }}
       - name: Extract SDK layer arn
         id: extract-sdk-layer-arn
         if: ${{ matrix.language != 'dotnet' }}
@@ -152,11 +158,17 @@ jobs:
         with:
           repository: aws-observability/aws-otel-test-framework
           path: test-framework
-      - name: validate sample
+      - name: validate trace sample
         run: |
-          cp ${{ matrix.expected_template }} test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cp ${{ matrix.expected_trace_template }} test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
           cd test-framework
-          ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
+          ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-amp-endpoint.outputs.stdout }} --region $AWS_REGION"
+      - name: validate java agent metric sample
+        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        run: |
+          cp ${{ matrix.expected_metric_template }} test-framework/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+          cd test-framework
+          ./gradlew :validator:run --args="-c prometheus-static-metric-validation.yml --cortex-instance-endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
       - name: Destroy terraform
         if: always()
         run: terraform destroy -auto-approve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,28 +146,29 @@ jobs:
             build_directory: java
             build_command: ./build.sh
             terraform_directory: sample-apps/java-agent-aws-sdk-terraform
-            expected_template: adot/utils/expected-templates/java-awssdk-agent.json
+            expected_trace_template: adot/utils/expected-templates/java-awssdk-agent.json
+            expected_metric_template: adot/utils/expected-templates/java-awssdk-agent-metric.json
           - name: java-awssdk-wrapper
             layer_kind: java-wrapper
             language: java
             build_directory: java
             build_command: ./build.sh
             terraform_directory: sample-apps/java-wrapper-aws-sdk-terraform
-            expected_template: adot/utils/expected-templates/java-awssdk-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/java-awssdk-wrapper.json
           - name: java-okhttp-wrapper
             layer_kind: java-wrapper
             language: java
             build_directory: java
             build_command: ./build.sh
             terraform_directory: sample-apps/java-wrapper-okhttp-terraform
-            expected_template: adot/utils/expected-templates/java-okhttp-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/java-okhttp-wrapper.json
           - name: nodejs-awssdk
             layer_kind: nodejs
             language: nodejs
             build_directory: opentelemetry-lambda/nodejs
             build_command: npm install
             terraform_directory: sample-apps/nodejs-aws-sdk-terraform
-            expected_template: adot/utils/expected-templates/nodejs-awssdk.json
+            expected_trace_template: adot/utils/expected-templates/nodejs-awssdk.json
           - name: python38
             layer_kind: python38
             language: python
@@ -176,14 +177,14 @@ jobs:
               cd sample-apps
               ./build.sh
             terraform_directory: sample-apps/python-aws-sdk-aiohttp-terraform
-            expected_template: adot/utils/expected-templates/python.json
+            expected_trace_template: adot/utils/expected-templates/python.json
           - name: dotnet-awssdk-wrapper
             layer_kind: collector
             language: dotnet
             build_directory: dotnet
             build_command: ./build.sh
             terraform_directory: sample-apps/dotnet-wrapper-aws-sdk-terraform
-            expected_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
     steps:
       - uses: actions/checkout@v2
         with:
@@ -269,6 +270,11 @@ jobs:
         id: extract-endpoint
         run: terraform output -raw api-gateway-url
         working-directory: ${{ matrix.terraform_directory }}
+      - name: Extract AMP endpoint
+        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        id: extract-amp-endpoint
+        run: terraform output -raw amp_endpoint
+        working-directory: ${{ matrix.terraform_directory }}
       - name: Send request to endpoint
         run: curl -sS ${{ steps.extract-endpoint.outputs.stdout }}
       - name: Checkout test framework
@@ -276,11 +282,17 @@ jobs:
         with:
           repository: aws-observability/aws-otel-test-framework
           path: test-framework
-      - name: validate sample
+      - name: validate trace sample
         run: |
-          cp ${{ matrix.expected_template }} test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cp ${{ matrix.expected_trace_template }} test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
           cd test-framework
           ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
+      - name: validate java agent metric sample
+        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        run: |
+          cp ${{ matrix.expected_metric_template }} test-framework/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+          cd test-framework
+          ./gradlew :validator:run --args="-c prometheus-static-metric-validation.yml --cortex-instance-endpoint ${{ steps.extract-amp-endpoint.outputs.stdout }} --region $AWS_REGION"
       - name: Destroy terraform
         if: always()
         run: terraform destroy -auto-approve

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -24,7 +24,8 @@ jobs:
             build_directory: java
             build_command: ./build.sh
             terraform_directory: integration-tests/java/aws-sdk/agent
-            expected_template: adot/utils/expected-templates/java-awssdk-agent.json
+            expected_trace_template: adot/utils/expected-templates/java-awssdk-agent.json
+            expected_metric_template: adot/utils/expected-templates/java-awssdk-agent-metric.json
             soak_config: '-c 200 -m 90'
           - name: java-awssdk-wrapper
             layer_kind: java-wrapper
@@ -32,7 +33,7 @@ jobs:
             build_directory: java
             build_command: ./build.sh
             terraform_directory: integration-tests/java/aws-sdk/wrapper
-            expected_template: adot/utils/expected-templates/java-awssdk-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/java-awssdk-wrapper.json
             soak_config: '-c 200 -m 90'
           - name: nodejs-awssdk
             layer_kind: nodejs
@@ -40,7 +41,7 @@ jobs:
             build_directory: nodejs
             build_command: ./build.sh
             terraform_directory: integration-tests/nodejs/aws-sdk
-            expected_template: adot/utils/expected-templates/nodejs-awssdk.json
+            expected_trace_template: adot/utils/expected-templates/nodejs-awssdk.json
             soak_config: '-c 90 -m 70'
           - name: python
             layer_kind: python38
@@ -48,7 +49,7 @@ jobs:
             build_directory: python
             build_command: ./build.sh
             terraform_directory: integration-tests/python/aws-sdk
-            expected_template: adot/utils/expected-templates/python.json
+            expected_trace_template: adot/utils/expected-templates/python.json
             soak_config: '-c 90 -m 70'
           - name: dotnet-awssdk-wrapper
             layer_kind: collector
@@ -56,7 +57,7 @@ jobs:
             build_directory: dotnet
             build_command: ./build.sh
             terraform_directory: integration-tests/dotnet/aws-sdk/wrapper
-            expected_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
+            expected_trace_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
             soak_config: '-c 200 -m 90'
     steps:
       - uses: actions/checkout@v2
@@ -146,6 +147,11 @@ jobs:
         id: extract-endpoint
         run: terraform output -raw api-gateway-url
         working-directory: ${{ matrix.terraform_directory }}
+      - name: Extract AMP endpoint
+        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        id: extract-amp-endpoint
+        run: terraform output -raw amp_endpoint
+        working-directory: ${{ matrix.terraform_directory }}
       - name: Extract SDK layer arn
         id: extract-sdk-layer-arn
         if: ${{ matrix.layer_kind != 'collector' }}
@@ -174,11 +180,17 @@ jobs:
         with:
           repository: aws-observability/aws-otel-test-framework
           path: test-framework
-      - name: validate sample
+      - name: validate trace sample
         run: |
-          cp ${{ matrix.expected_template }} test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cp ${{ matrix.expected_trace_template }} test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
           cd test-framework
           ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
+      - name: validate java agent metric sample
+        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        run: |
+          cp ${{ matrix.expected_metric_template }} test-framework/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
+          cd test-framework
+          ./gradlew :validator:run --args="-c prometheus-static-metric-validation.yml --cortex-instance-endpoint ${{ steps.extract-amp-endpoint.outputs.stdout }} --region $AWS_REGION"
       - name: Run soak test
         run: |
           docker run --rm -e AWS_DEFAULT_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \

--- a/adot/utils/expected-templates/java-awssdk-agent-metric.json
+++ b/adot/utils/expected-templates/java-awssdk-agent-metric.json
@@ -1,0 +1,7 @@
+[{"metric":
+    {"__name__":"queueSizeChange","apiName":"apiName","statuscode":"200"},
+  "value":
+    [],
+  "values":
+    []
+}]

--- a/integration-tests/java/aws-sdk/agent/main.tf
+++ b/integration-tests/java/aws-sdk/agent/main.tf
@@ -1,14 +1,66 @@
+data "aws_region" "current" {}
+
 module "test" {
   source = "../../../../opentelemetry-lambda/java/integration-tests/aws-sdk/agent"
 
-  enable_collector_layer = false
-  sdk_layer_name         = var.sdk_layer_name
-  function_name          = var.function_name
+  enable_collector_layer     = false
+  sdk_layer_name             = var.sdk_layer_name
+  function_name              = var.function_name
+  collector_config_layer_arn = aws_lambda_layer_version.collector_config_layer.arn
+  tracing_mode               = "Active"
+}
 
-  tracing_mode = "Active"
+resource "aws_prometheus_workspace" "test_amp_workspace" {}
+
+data "archive_file" "init" {
+  type       = "zip"
+  depends_on = [aws_prometheus_workspace.test_amp_workspace, data.aws_region.current]
+  source {
+    content  = <<EOT
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  logging:
+  awsxray:
+  awsprometheusremotewrite:
+    endpoint: "${aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint}api/v1/remote_write"
+    aws_auth:
+      service: "aps"
+      region: "${data.aws_region.current.name}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      exporters: [logging, awsprometheusremotewrite]
+EOT
+    filename = "config.yaml"
+  }
+
+  output_path = "${path.module}/build/custom-config-layer.zip"
 }
 
 resource "aws_iam_role_policy_attachment" "test_xray" {
   role       = module.test.function_role_name
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "test_amp" {
+  role       = module.test.function_role_name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusFullAccess"
+}
+
+resource "aws_lambda_layer_version" "collector_config_layer" {
+  depends_on          = [data.archive_file.init]
+  layer_name          = "custom-config-layer"
+  filename            = "${path.module}/build/custom-config-layer.zip"
+  compatible_runtimes = ["java8", "java8.al2", "java11"]
+  license_info        = "Apache-2.0"
 }

--- a/integration-tests/java/aws-sdk/agent/outputs.tf
+++ b/integration-tests/java/aws-sdk/agent/outputs.tf
@@ -5,3 +5,7 @@ output "api-gateway-url" {
 output "sdk-layer-arn" {
   value = module.test.sdk_layer_arn
 }
+
+output "amp_endpoint" {
+  value = aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint
+}

--- a/integration-tests/java/aws-sdk/agent/variables.tf
+++ b/integration-tests/java/aws-sdk/agent/variables.tf
@@ -7,7 +7,13 @@ variable "collector_layer_name" {
 variable "sdk_layer_name" {
   type        = string
   description = "Name of published SDK layer"
-  default     = "opentelemetry-nodejs-wrapper"
+  default     = "opentelemetry-java-agent"
+}
+
+variable "collector_config_layer_name" {
+  type        = string
+  description = "Name of published custom config layer"
+  default     = "custom-collector-config"
 }
 
 variable "function_name" {
@@ -15,3 +21,4 @@ variable "function_name" {
   description = "Name of sample app function / API gateway"
   default     = "hello-java-awssdk-agent"
 }
+

--- a/java/build.sh
+++ b/java/build.sh
@@ -17,7 +17,7 @@ cp ./build/libs/aws-otel-lambda-java-extensions.jar ../opentelemetry-lambda/java
 
 cd ../opentelemetry-lambda/java || exit
 
-./gradlew build -Potel.lambda.javaagent.dependency=software.amazon.opentelemetry:aws-opentelemetry-agent:1.2.0
+./gradlew build -Potel.lambda.javaagent.dependency=software.amazon.opentelemetry:aws-opentelemetry-agent:1.4.0
 
 # Combine the layers
 

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -1,7 +1,7 @@
 cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 # replace collector with AOC
-go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.11.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.0.0-20210708212027-05f20388cb49
 go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.29.1-0.20210630203112-81d57601b1bc
 go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.29.1-0.20210630203112-81d57601b1bc
 go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.29.1-0.20210630203112-81d57601b1bc

--- a/sample-apps/java-agent-aws-sdk-terraform/layer.tf
+++ b/sample-apps/java-agent-aws-sdk-terraform/layer.tf
@@ -1,4 +1,5 @@
 locals {
+  # TODO: update all arns to the updated java-agent layer with the AWS PRW exporter 
   sdk_layer_arns = {
     "ap-northeast-1" = "arn:aws:lambda:ap-northeast-1:901920570463:layer:aws-otel-java-agent-ver-1-2-0:2"
     "ap-northeast-2" = "arn:aws:lambda:ap-northeast-2:901920570463:layer:aws-otel-java-agent-ver-1-2-0:2"

--- a/sample-apps/java-agent-aws-sdk-terraform/main.tf
+++ b/sample-apps/java-agent-aws-sdk-terraform/main.tf
@@ -3,13 +3,64 @@ data "aws_region" "current" {}
 module "app" {
   source = "../../opentelemetry-lambda/java/sample-apps/aws-sdk/deploy/agent"
 
-  name                = var.function_name
-  collector_layer_arn = null
-  sdk_layer_arn       = lookup(local.sdk_layer_arns, data.aws_region.current.name, "invalid")
-  tracing_mode        = "Active"
+  name                       = var.function_name
+  collector_layer_arn        = null
+  sdk_layer_arn              = lookup(local.sdk_layer_arns, data.aws_region.current.name, "invalid")
+  collector_config_layer_arn = aws_lambda_layer_version.collector_config_layer.arn
+  tracing_mode               = "Active"
 }
 
 resource "aws_iam_role_policy_attachment" "test_xray" {
   role       = module.app.function_role_name
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "test_amp" {
+  role       = module.app.function_role_name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusFullAccess"
+}
+
+resource "aws_prometheus_workspace" "test_amp_workspace" {}
+
+data "archive_file" "init" {
+  type       = "zip"
+  depends_on = [aws_prometheus_workspace.test_amp_workspace, data.aws_region.current]
+  source {
+    content  = <<EOT
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  logging:
+  awsxray:
+  awsprometheusremotewrite:
+    endpoint: "${aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint}api/v1/remote_write"
+    aws_auth:
+      service: "aps"
+      region: "${data.aws_region.current.name}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      exporters: [logging, awsprometheusremotewrite]
+EOT
+    filename = "config.yaml"
+  }
+
+  output_path = "${path.module}/build/custom-config-layer.zip"
+}
+
+resource "aws_lambda_layer_version" "collector_config_layer" {
+  depends_on          = [data.archive_file.init]
+  layer_name          = "custom-config-layer"
+  filename            = "${path.module}/build/custom-config-layer.zip"
+  compatible_runtimes = ["java8", "java8.al2", "java11"]
+  license_info        = "Apache-2.0"
 }

--- a/sample-apps/java-agent-aws-sdk-terraform/outputs.tf
+++ b/sample-apps/java-agent-aws-sdk-terraform/outputs.tf
@@ -1,3 +1,11 @@
 output "api-gateway-url" {
   value = module.app.api-gateway-url
 }
+
+output "collector_config_layer_arn" {
+  value = aws_lambda_layer_version.collector_config_layer.arn
+}
+
+output "amp_endpoint" {
+  value = aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint
+}


### PR DESCRIPTION
**Description:**  

This PR:
* Pulls in the most recent changes of the [Java AWS SDK agent sample application ](https://github.com/open-o11y/opentelemetry-lambda/tree/main/java/sample-apps/aws-sdk) to the submodule
   - Note: the submodule will need another update to include [this PR](https://github.com/open-telemetry/opentelemetry-lambda/pull/132) before merging 
* Updates the Terraform configuration for the  java-awssdk-agent sample application to  dynamically generate an AMP endpoint and deploy the custom collector configuration file with the application to a separate Lambda layer 
*  Updates the CI workflow files to ensure the metric generated  from the sample application to AMP is being received as exected, using the AMP Metric Validator. 



**Link to tracking Issue:** 
None

**Testing:** 
The metric validation was tested locally with the command `./gradlew :validator:run --args="-c prometheus-static-metric-validation.yml -cortex-instance-endpoint <amp-endpoint> --region <region>`. 

**Documentation:** 
N/A