### PR TITLE
Only provision AMP resources in supported regions for java-awssdk-agent sample app

### DIFF
--- a/integration-tests/java/aws-sdk/agent/main.tf
+++ b/integration-tests/java/aws-sdk/agent/main.tf
@@ -6,14 +6,17 @@ module "test" {
   enable_collector_layer     = false
   sdk_layer_name             = var.sdk_layer_name
   function_name              = var.function_name
-  collector_config_layer_arn = aws_lambda_layer_version.collector_config_layer.arn
+  collector_config_layer_arn = length(aws_lambda_layer_version.collector_config_layer) > 0 ? aws_lambda_layer_version.collector_config_layer[0].arn : null
   tracing_mode               = "Active"
 }
 
-resource "aws_prometheus_workspace" "test_amp_workspace" {}
+resource "aws_prometheus_workspace" "test_amp_workspace" {
+  count = contains(["us-west-2", "us-east-1", "us-east-2", "eu-central-1", "eu-west-1"], data.aws_region.current.name) ? 1 : 0
+}
 
 data "archive_file" "init" {
   type       = "zip"
+  count      = length(aws_prometheus_workspace.test_amp_workspace) > 0 ? 1 : 0
   depends_on = [aws_prometheus_workspace.test_amp_workspace, data.aws_region.current]
   source {
     content  = <<EOT
@@ -27,7 +30,7 @@ exporters:
   logging:
   awsxray:
   awsprometheusremotewrite:
-    endpoint: "${aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint}api/v1/remote_write"
+    endpoint: "${aws_prometheus_workspace.test_amp_workspace[0].prometheus_endpoint}api/v1/remote_write"
     aws_auth:
       service: "aps"
       region: "${data.aws_region.current.name}"
@@ -58,6 +61,7 @@ resource "aws_iam_role_policy_attachment" "test_amp" {
 }
 
 resource "aws_lambda_layer_version" "collector_config_layer" {
+  count               = length(data.archive_file.init) > 0 ? 1 : 0
   depends_on          = [data.archive_file.init]
   layer_name          = "custom-config-layer"
   filename            = "${path.module}/build/custom-config-layer.zip"

--- a/integration-tests/java/aws-sdk/agent/outputs.tf
+++ b/integration-tests/java/aws-sdk/agent/outputs.tf
@@ -7,5 +7,5 @@ output "sdk-layer-arn" {
 }
 
 output "amp_endpoint" {
-  value = aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint
+  value = length(aws_prometheus_workspace.test_amp_workspace) > 0 ? aws_prometheus_workspace.test_amp_workspace[0].prometheus_endpoint : null
 }

--- a/sample-apps/java-agent-aws-sdk-terraform/outputs.tf
+++ b/sample-apps/java-agent-aws-sdk-terraform/outputs.tf
@@ -3,9 +3,9 @@ output "api-gateway-url" {
 }
 
 output "collector_config_layer_arn" {
-  value = aws_lambda_layer_version.collector_config_layer.arn
+  value = length(aws_lambda_layer_version.collector_config_layer) > 0 ? aws_lambda_layer_version.collector_config_layer[0].arn : null
 }
 
 output "amp_endpoint" {
-  value = aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint
+  value = length(aws_prometheus_workspace.test_amp_workspace) > 0 ? aws_prometheus_workspace.test_amp_workspace[0].prometheus_endpoint : null
 }


### PR DESCRIPTION
Specified in the Terraform configuration for the Java AWS SDK Agent sample app to only provision AMP resources if run in one of the five currently supported [AMP Supported Regions](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP_quotas.html) 