### PR TITLE
Update soak tests to only check endpoint in AMP regions

### DIFF
--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -24,6 +24,7 @@ jobs:
             build_directory: java
             build_command: ./build.sh
             terraform_directory: integration-tests/java/aws-sdk/agent
+            amp_regions: [ "us-west-2", "us-east-1", "us-east-2", "eu-central-1", "eu-west-1"]
             expected_trace_template: adot/utils/expected-templates/java-awssdk-agent.json
             expected_metric_template: adot/utils/expected-templates/java-awssdk-agent-metric.json
             soak_config: '-c 200 -m 90'
@@ -148,7 +149,7 @@ jobs:
         run: terraform output -raw api-gateway-url
         working-directory: ${{ matrix.terraform_directory }}
       - name: Extract AMP endpoint
-        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        if: ${{ matrix.name == 'java-awssdk-agent' && contains(matrix.amp_regions, matrix.aws_region)}}
         id: extract-amp-endpoint
         run: terraform output -raw amp_endpoint
         working-directory: ${{ matrix.terraform_directory }}
@@ -186,7 +187,7 @@ jobs:
           cd test-framework
           ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
       - name: validate java agent metric sample
-        if: ${{ matrix.name == 'java-awssdk-agent' }}
+        if: ${{ matrix.name == 'java-awssdk-agent' && contains(matrix.amp_regions, matrix.aws_region)}}
         run: |
           cp ${{ matrix.expected_metric_template }} test-framework/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache
           cd test-framework


### PR DESCRIPTION
Missed an extra check in the soak tests for AMP regions - fixed to now match the [canary workflow](https://github.com/aws-observability/aws-otel-lambda/blob/main/.github/workflows/canary.yml#L31)