### PR TITLE
Use OTEL_SERVICE_NAME variable to set service name.

### DIFF
--- a/java/scripts/otel-handler
+++ b/java/scripts/otel-handler
@@ -4,5 +4,10 @@ export OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES=true
 
 export OTEL_PROPAGATORS="${OTEL_PROPAGATORS:-xray,tracecontext,b3,b3multi}"
 
+# Temporarily set OTEL_SERVICE_NAME variable to work around but in javaagent not handling
+# OTEL_RESOURCE_ATTRIBUTES as set in otel-handler-upstream. It doesn't hurt to apply this
+# to wrapper as well.
+# TODO(anuraaga): Move to opentelemetry-lambda
+export OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-${AWS_LAMBDA_FUNCTION_NAME}}
 
 source /opt/otel-handler-upstream


### PR DESCRIPTION
**Description:** <Describe what has changed. 

Upstream OTel javaagent 1.5 has a bug in parsing map attribute values. Currently the lambda handler scripts use the `OTEL_RESOURCE_ATTRIBUTES` map value to set service name, which isn't working with the agent anymore. Luckily, a new variable that isn't a map, `OTEL_SERVICE_NAME` was recently introduced so we can just switch to it.

Adding here for now and will add it upstream too

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
