### PR TITLE
Lambda Layer Update - OTel JS 1.0.3 and 0.26.0

### DIFF
--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -37,11 +37,11 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.0.3",
-    "@opentelemetry/core": "^0.25.0",
-    "@opentelemetry/id-generator-aws-xray": "^0.24.0",
-    "@opentelemetry/sdk-trace-node": "^0.25.0",
-    "@opentelemetry/propagator-aws-xray": "^0.24.0",
-    "@opentelemetry/propagator-b3": "^0.25.0"
+    "@opentelemetry/api": "^1.0.3",
+    "@opentelemetry/core": "^1.0.0",
+    "@opentelemetry/id-generator-aws-xray": "^1.0.0",
+    "@opentelemetry/sdk-trace-node": "^1.0.0",
+    "@opentelemetry/propagator-aws-xray": "^1.0.0",
+    "@opentelemetry/propagator-b3": "^1.0.0"
   }
 }


### PR DESCRIPTION
**Description:**

Follow up to upstream PR https://github.com/open-telemetry/opentelemetry-lambda/pull/169. We follow upstream's update to OTel JS 1.03 and 0.27.0 in this PR.

**Link to tracking Issue:**

N/A

**Testing:**

No testing done here, but Soak Tests should catch failures.

**Documentation:**

N/A (Will follow up with repo README change once all languages have been released)
