### PR TITLE
Lambda Layer Update - OTel Collector 0.38.0 + Sync Upstream for Oct 2021 Release

### DIFF
--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -1,8 +1,8 @@
 cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 # replace collector with AOC
-go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.13.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.36.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.36.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.36.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.14.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.38.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.38.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.38.0
 go mod tidy


### PR DESCRIPTION
**Description:**

Upstream has made several changes and we want to create a release of Lambda layers which includes them! This is part of our October 2021 release.

In this PR we updated `./patch-upstream.sh` to use version `0.38.0` of our ADOT distributions of the collector and also synchronized our references of upstream to the latest commits.

**Link to tracking Issue:**

N/A

**Testing:**

N/A

**Documentation:**

N/A
