### PR TITLE
Update expected python template for new OTel Python AWS SDK Instrumentation

### DIFF
--- a/adot/utils/expected-templates/python.json
+++ b/adot/utils/expected-templates/python.json
@@ -9,7 +9,22 @@
     "name":"hello-lambda-python.*"
   },
   {
-    "name":"hello-lambda-python.*"
+    "name":"hello-lambda-python.*",
+    "subsegments": [
+      {
+          "name": "HTTP GET"
+      },
+      {
+          "name": "S3",
+          "metadata": {
+              "default": {
+                  "rpc.service": "S3",
+                  "rpc.method": "ListBuckets",
+                  "rpc.system": "aws-api"
+              }
+          }
+      }
+    ]
   },
   {
     "name":"HTTP GET",
@@ -24,9 +39,6 @@
   {
     "name":"S3",
     "origin":"AWS::S3",
-    "inferred":true,
-    "aws":{
-      "operation":"ListBuckets"
-    }
+    "inferred":true
   }
 ]


### PR DESCRIPTION
## Description

OTel Python has updated [their instrumentation to not populate the `aws.operation`](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/674/files#diff-05ef2bbeb79bb2d595bf8a3f7fa2d475d0f34f80804e5e1ba0d9a253d2c0e0e3L239) attribute anymore. They did this because [the specification defined how to instrument the AWS SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/20c82de552d08428e8cadaaef3e6cb46812f7c00/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#common-attributes).

We updated the [template on the test-framework](https://github.com/aws-observability/aws-otel-test-framework/pull/349) to account for this change, but as the `main-build.yml` revealed, we were expecting the "operation" on the trace INFERRED BY AWS X-RAY SERVICE TEAM:

https://github.com/aws-observability/aws-otel-lambda/blob/5dd1b69f765bc5d389bf045c37cbfe9c483b70c3/adot/utils/expected-templates/python.json#L24-L32

However, the service team implementation must not know to read from the metadata attributes as this spec is so new.

## Impact

**Before** - user could see `ListBuckets` in the X-Ray console at these points:

![Screen Shot 2021-11-01 at 6 11 29 PM](https://user-images.githubusercontent.com/23139455/139748963-a045aff4-8a85-4207-9eb9-44c772fe828c.png)

**After** - now, use cannot see anything here:

![Screen Shot 2021-11-01 at 6 12 47 PM](https://user-images.githubusercontent.com/23139455/139749014-bb2b8f93-e7b7-4fd4-a0a9-63f311ca0c49.png)

**However**, they _can still find_ the "operation" if they look at the metadata of the subsegment span sent by OpenTelemetry Python (previously and still now):

![Screen Shot 2021-11-01 at 6 08 41 PM](https://user-images.githubusercontent.com/23139455/139749186-aef91565-b81d-4e54-88b5-f5896da62d90.png)
![Screen Shot 2021-11-01 at 6 09 03 PM](https://user-images.githubusercontent.com/23139455/139749188-911a72fb-f2da-4308-bd93-497efffbac50.png)

## Solutions

1. We can use the [OTel Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/25c063f8df2b64713e7e0aad7d6963af17b87364/exporter/awsxrayexporter/internal/translator/aws.go#L1290 to map `rpc.service` to `aws.operation` and that way the service team implementation can pick it up as is
2. We can ask the service team to read `rpc.operation` instead of `aws.operation` to populate the operation.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
