### PR TITLE
Handle propagator rename breaking change in OTel JS 0.26.0

### DIFF
--- a/nodejs/build.sh
+++ b/nodejs/build.sh
@@ -11,10 +11,10 @@ popd || exit
 # Build the sdk layer and sample apps
 
 cd wrapper-adot || exit
-npm install
+npm install || exit
 
 cd ../../opentelemetry-lambda/nodejs || exit
-npm install
+npm install || exit
 
 mv ./packages/layer/build/workspace/otel-handler ./packages/layer/build/workspace/otel-handler-upstream
 cp "$SOURCEDIR"/scripts/otel-handler ./packages/layer/build/workspace/otel-handler

--- a/nodejs/wrapper-adot/src/adot-extension.ts
+++ b/nodejs/wrapper-adot/src/adot-extension.ts
@@ -1,5 +1,5 @@
 import { propagation } from '@opentelemetry/api';
-import { CompositePropagator, HttpTraceContextPropagator } from '@opentelemetry/core';
+import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { NodeTracerConfig } from '@opentelemetry/sdk-trace-node';
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { AWSXRayIdGenerator } from '@opentelemetry/id-generator-aws-xray';
@@ -14,7 +14,7 @@ if (!process.env.OTEL_PROPAGATORS) {
     new CompositePropagator({
       propagators: [
         new AWSXRayPropagator(),
-        new HttpTraceContextPropagator(),
+        new W3CTraceContextPropagator(),
         new B3Propagator(),
         new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
       ],


### PR DESCRIPTION
**Description:**

The [OTel JS upgrading guide](https://github.com/open-telemetry/opentelemetry-js#024x-to-025x) had said that the `HttpTraceContextPropagator` was renamed in `0.25.0` so since we were upgrading from `0.25.0` to `0.26.0` there should have been no need to change anything. However, this breaking change (https://github.com/open-telemetry/opentelemetry-js/pull/2429) was actually introduced in `0.26.0` as seen by [the OTel JS release notes](https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.26.0). Therefore, we need to account for that in this `0.26.0` release.

**Link to tracking Issue:**

N/A

**Testing:**

This time, I confirmed there were no error outputs when I did `cd nodejs/ && ./build.sh` even after scrolling to the top.

**Documentation:**

N/A