### PR TITLE
Revert Python Template Changes - Wait for regression fix

### DIFF
--- a/adot/utils/expected-templates/python.json
+++ b/adot/utils/expected-templates/python.json
@@ -9,22 +9,7 @@
     "name":"hello-lambda-python.*"
   },
   {
-    "name":"hello-lambda-python.*",
-    "subsegments": [
-      {
-          "name": "HTTP GET"
-      },
-      {
-          "name": "S3",
-          "metadata": {
-              "default": {
-                  "rpc.service": "S3",
-                  "rpc.method": "ListBuckets",
-                  "rpc.system": "aws-api"
-              }
-          }
-      }
-    ]
+    "name":"hello-lambda-python.*"
   },
   {
     "name":"HTTP GET",
@@ -39,6 +24,9 @@
   {
     "name":"S3",
     "origin":"AWS::S3",
-    "inferred":true
+    "inferred":true,
+    "aws":{
+      "operation":"ListBuckets"
+    }
   }
 ]


### PR DESCRIPTION
**Description:**

Reverts #165

**The regression is still an issue**, but we would rather have the `main-build.yml` workflow fail because this tells us that the current local implementation has a regression and should not be published.

Otherwise, if we do not do this, the `canary.yml` workflow fails because it uses the template to test the latest published version. Since we will not publish a version with a regression, we would rather the `canary.yml` file continue to use the template which works with the latest published Layer.

**Link to tracking Issue:**

Regression issue is being tracked in OTel Collector Contrib: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6109

**Testing:**

N/A, `canary.yml` should pass and `main-build.yml` should fail.

**Documentation:**

N/A
