### PR TITLE
Use .NET for Collector Lambda Layer tests

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -22,7 +22,10 @@ jobs:
           - nodejs-awssdk
           - python38
           - dotnet-awssdk-wrapper
-          - go-awssdk-wrapper
+          # TODO: Uncomment this once Go Lambda Layer has a working published
+          # version. Right now since there is no published layer this is just
+          # causing failures on the canary test that have no action items.
+          # - go-awssdk-wrapper
         include:
           - name: java-awssdk-agent
             language: java
@@ -64,12 +67,12 @@ jobs:
             build_command: ./build.sh
             terraform_directory: sample-apps/dotnet-wrapper-aws-sdk-terraform
             expected_trace_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
-          - name: go-awssdk-wrapper
-            language: go
-            build_directory: go
-            build_command: ./build.sh
-            terraform_directory: sample-apps/go-wrapper-aws-sdk-terraform
-            expected_trace_template: adot/utils/expected-templates/go-awssdk-wrapper.json
+          # - name: go-awssdk-wrapper
+          #   language: go
+          #   build_directory: go
+          #   build_command: ./build.sh
+          #   terraform_directory: sample-apps/go-wrapper-aws-sdk-terraform
+          #   expected_trace_template: adot/utils/expected-templates/go-awssdk-wrapper.json
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,11 @@ jobs:
           echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/java-awssdk-agent.json" >> $GITHUB_ENV;
           echo "EXPECTED_METRIC_TEMPLATE=adot/utils/expected-templates/java-awssdk-agent-metric.json" >> $GITHUB_ENV;
           echo "AMP_REGIONS=us-west-2,us-east-1,us-east-2,eu-central-1,eu-west-1" >> $GITHUB_ENV;
+        # FIXME: (enowell) You can only Smoke Test 1 Sample App with this
+        # design. However, there are multiple Sample Apps that test the same
+        # Java Wrapper Lambda Layer. (`java-wrapper-aws-sdk-terraform`
+        # and `java-wrapper-okhttp-terraform`). We should create a new workflow
+        # to test all Sample Apps on the same Layer.
       - name: Configure Java Wrapper Values
         if: ${{ github.event.inputs.layer_kind == 'java-wrapper' }}
         run: |-
@@ -174,18 +179,19 @@ jobs:
           echo "BUILD_COMMAND=./build.sh" >> $GITHUB_ENV;
           echo "TERRAFORM_DIRECTORY=sample-apps/python-aws-sdk-aiohttp-terraform" >> $GITHUB_ENV;
           echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/python.json" >> $GITHUB_ENV;
-        # FIXME: (enowell) You can only Smoke Test 1 Sample App with this design. We will want to test
-        # multiple in the future (i.e. Go/.NET Sample Apps with the same Collector Layer).
-        # TODO: Add and Test .NET Lambda app in the same collector-only (Same used in Go) Lambda Layer in smoke test
+        # FIXME: (enowell) You can only Smoke Test 1 Sample App with this
+        # design. However, both .NET and Go Sample Apps test the collector-only
+        # Lambda layer. For now we only test .NET, but we should make a new
+        # workflow to test all sample apps using the same Lambda Layer.
       - name: Configure Collector Values
         if: ${{ github.event.inputs.layer_kind == 'collector' }}
         run: |-
           echo "SAMPLE_APP_NAME=dotnet-awssdk-wrapper" >> $GITHUB_ENV;
-          echo "LANGUAGE=go" >> $GITHUB_ENV;
-          echo "BUILD_DIRECTORY=go" >> $GITHUB_ENV;
+          echo "LANGUAGE=dotnet" >> $GITHUB_ENV;
+          echo "BUILD_DIRECTORY=dotnet" >> $GITHUB_ENV;
           echo "BUILD_COMMAND=./build.sh" >> $GITHUB_ENV;
-          echo "TERRAFORM_DIRECTORY=sample-apps/go-wrapper-aws-sdk-terraform" >> $GITHUB_ENV;
-          echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/go-awssdk-wrapper.json" >> $GITHUB_ENV;
+          echo "TERRAFORM_DIRECTORY=sample-apps/dotnet-wrapper-aws-sdk-terraform" >> $GITHUB_ENV;
+          echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/dotnet-awssdk-wrapper.json" >> $GITHUB_ENV;
       - name: Set Configuration Outputs
         id: set-smoke-test-outputs
         run: |-
@@ -252,10 +258,10 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - uses: actions/setup-go@v2
-        if: ${{ needs.get-smoke-test-configuration.outputs.language == 'go' }}
+      - uses: actions/setup-dotnet@v1
+        if: ${{ needs.get-smoke-test-configuration.outputs.language == 'dotnet' }}
         with:
-          go-version: '^1.16'
+          dotnet-version: '3.1.x'
       - name: download layer tf file
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -51,14 +51,19 @@ jobs:
             terraform_directory: integration-tests/python/aws-sdk
             expected_trace_template: adot/utils/expected-templates/python.json
             soak_config: '-c 90 -m 70'
-          # TODO: Add and Test .NET Lambda app in the same collector-only (Same used in Go) Lambda Layer in Soak test
-          - name: go-awssdk-wrapper
+            # FIXME: (enowell) Both .NET and Go Sample Apps want to Soak Test
+            # the same collector-only lambda layer. We count on Soaking Tests to
+            # test whether a layer is ready for release. However, the current
+            # workflow can only test one Sample App per Lambda Layer. We should
+            # create a separate workflow to soak-test Layers with multiple
+            # soak tests.
+          - name: dotnet-awssdk-wrapper
             layer_kind: collector
-            language: go
-            build_directory: go
+            language: dotnet
+            build_directory: dotnet
             build_command: ./build.sh
-            terraform_directory: integration-tests/go/aws-sdk
-            expected_trace_template: adot/utils/expected-templates/go-awssdk-wrapper.json
+            terraform_directory: integration-tests/dotnet/aws-sdk/wrapper
+            expected_trace_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
             soak_config: '-c 200 -m 90'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Description:**

Follow up to #127

Some unforeseen blockers are causing the Go Lambda Layer to fail. To unblock us for now, we will go back to using .NET to verify the Collector-only Lambda Layer is working so that we can get it released and make the tests go green.

**Link to tracking Issue:**

N/A

**Testing:**

.NET did not change and the tests were working before, so we expect the `Canary` and `Soaking` tests to go green and that the `Release` tests remain green.

**Documentation:**

N/A
