### PR TITLE
Combine spec and X-Ray backend attributes into python template

### DIFF
--- a/adot/utils/expected-templates/python.json
+++ b/adot/utils/expected-templates/python.json
@@ -9,7 +9,27 @@
     "name":"hello-lambda-python.*"
   },
   {
-    "name":"hello-lambda-python.*"
+    "name":"hello-lambda-python.*",
+    "subsegments": [
+      {
+          "name": "HTTP GET"
+      },
+      {
+          "name": "S3",
+          "aws": {
+            "operation": "ListBuckets"
+          },
+          "metadata": {
+            "default": {
+              "aws.service": "s3",
+              "rpc.service": "S3",
+              "rpc.method": "ListBuckets",
+              "rpc.system": "aws-api"
+            }
+          },
+          "namespace": "aws"
+      }
+    ]
   },
   {
     "name":"HTTP GET",

--- a/adot/utils/expected-templates/python.json
+++ b/adot/utils/expected-templates/python.json
@@ -19,14 +19,6 @@
           "aws": {
             "operation": "ListBuckets"
           },
-          "metadata": {
-            "default": {
-              "aws.service": "s3",
-              "rpc.service": "S3",
-              "rpc.method": "ListBuckets",
-              "rpc.system": "aws-api"
-            }
-          },
           "namespace": "aws"
       }
     ]


### PR DESCRIPTION
**Description:**

Similar to https://github.com/aws-observability/aws-otel-test-framework/pull/383, this PR is meant to update the template to incorporate BOTH [the spec defined attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#common-attributes) and the attributes we need the Collector to set for the X-Ray backend to read https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6109

**Merge once** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6109 is FIXED.

**Link to tracking Issue:**

Fixes #170

**Testing:**

Read more about why we know these are the changes we need in https://github.com/aws-observability/aws-otel-test-framework/pull/383. Once this merges the `main-build.yml` for Python **should start passing again**.

**Documentation:**

N/A
