### PR TITLE
Use go for soaking + release + canary workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -22,10 +22,7 @@ jobs:
           - nodejs-awssdk
           - python38
           - dotnet-awssdk-wrapper
-          # TODO: Uncomment this once Go Lambda Layer has a working published
-          # version. Right now since there is no published layer this is just
-          # causing failures on the canary test that have no action items.
-          # - go-awssdk-wrapper
+          - go-awssdk-wrapper
         include:
           - name: java-awssdk-agent
             language: java
@@ -67,12 +64,12 @@ jobs:
             build_command: ./build.sh
             terraform_directory: sample-apps/dotnet-wrapper-aws-sdk-terraform
             expected_trace_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
-          # - name: go-awssdk-wrapper
-          #   language: go
-          #   build_directory: go
-          #   build_command: ./build.sh
-          #   terraform_directory: sample-apps/go-wrapper-aws-sdk-terraform
-          #   expected_trace_template: adot/utils/expected-templates/go-awssdk-wrapper.json
+          - name: go-awssdk-wrapper
+            language: go
+            build_directory: go
+            build_command: ./build.sh
+            terraform_directory: sample-apps/go-wrapper-aws-sdk-terraform
+            expected_trace_template: adot/utils/expected-templates/go-awssdk-wrapper.json
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,19 +179,29 @@ jobs:
           echo "BUILD_COMMAND=./build.sh" >> $GITHUB_ENV;
           echo "TERRAFORM_DIRECTORY=sample-apps/python-aws-sdk-aiohttp-terraform" >> $GITHUB_ENV;
           echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/python.json" >> $GITHUB_ENV;
-        # FIXME: (enowell) You can only Smoke Test 1 Sample App with this
-        # design. However, both .NET and Go Sample Apps test the collector-only
-        # Lambda layer. For now we only test .NET, but we should make a new
-        # workflow to test all sample apps using the same Lambda Layer.
+      # FIXME: (enowell) You can only Smoke Test 1 Sample App with this
+      # design. However, both .NET and Go Sample Apps test the collector-only
+      # Lambda layer. For now we only test Go, but we should either make a new
+      # workflow to test all sample apps using the same Lambda Layer or make
+      # a new layer for just .NET/Go.
+      # - name: Configure Collector Values
+      #   if: ${{ github.event.inputs.layer_kind == 'collector' }}
+      #   run: |-
+      #     echo "SAMPLE_APP_NAME=dotnet-awssdk-wrapper" >> $GITHUB_ENV;
+      #     echo "LANGUAGE=dotnet" >> $GITHUB_ENV;
+      #     echo "BUILD_DIRECTORY=dotnet" >> $GITHUB_ENV;
+      #     echo "BUILD_COMMAND=./build.sh" >> $GITHUB_ENV;
+      #     echo "TERRAFORM_DIRECTORY=sample-apps/dotnet-wrapper-aws-sdk-terraform" >> $GITHUB_ENV;
+      #     echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/dotnet-awssdk-wrapper.json" >> $GITHUB_ENV;
       - name: Configure Collector Values
         if: ${{ github.event.inputs.layer_kind == 'collector' }}
         run: |-
           echo "SAMPLE_APP_NAME=dotnet-awssdk-wrapper" >> $GITHUB_ENV;
-          echo "LANGUAGE=dotnet" >> $GITHUB_ENV;
-          echo "BUILD_DIRECTORY=dotnet" >> $GITHUB_ENV;
+          echo "LANGUAGE=go" >> $GITHUB_ENV;
+          echo "BUILD_DIRECTORY=go" >> $GITHUB_ENV;
           echo "BUILD_COMMAND=./build.sh" >> $GITHUB_ENV;
-          echo "TERRAFORM_DIRECTORY=sample-apps/dotnet-wrapper-aws-sdk-terraform" >> $GITHUB_ENV;
-          echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/dotnet-awssdk-wrapper.json" >> $GITHUB_ENV;
+          echo "TERRAFORM_DIRECTORY=sample-apps/go-wrapper-aws-sdk-terraform" >> $GITHUB_ENV;
+          echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/go-awssdk-wrapper.json" >> $GITHUB_ENV;
       - name: Set Configuration Outputs
         id: set-smoke-test-outputs
         run: |-
@@ -258,10 +268,18 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - uses: actions/setup-dotnet@v1
-        if: ${{ needs.get-smoke-test-configuration.outputs.language == 'dotnet' }}
+      # FIXME: (enowell) Same as above - .NET uses the collector layer, but we
+      # only test Go with the collector layer so comment out for now.
+      # - name: Use .NET Language
+      #   uses: actions/setup-dotnet@v1
+      #   if: ${{ needs.get-smoke-test-configuration.outputs.language == 'dotnet' }}
+      #   with:
+      #     dotnet-version: '3.1.x'
+      - name: Use Go Language
+        uses: actions/setup-go@v2
+        if: ${{ needs.get-smoke-test-configuration.outputs.language == 'go' }}
         with:
-          dotnet-version: '3.1.x'
+          go-version: '^1.16'
       - name: download layer tf file
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -57,13 +57,13 @@ jobs:
             # workflow can only test one Sample App per Lambda Layer. We should
             # create a separate workflow to soak-test Layers with multiple
             # soak tests.
-          - name: dotnet-awssdk-wrapper
+          - name: go-awssdk-wrapper
             layer_kind: collector
-            language: dotnet
-            build_directory: dotnet
+            language: go
+            build_directory: go
             build_command: ./build.sh
-            terraform_directory: integration-tests/dotnet/aws-sdk/wrapper
-            expected_trace_template: adot/utils/expected-templates/dotnet-awssdk-wrapper.json
+            terraform_directory: integration-tests/go/aws-sdk/wrapper
+            expected_trace_template: adot/utils/expected-templates/go-awssdk-wrapper.json
             soak_config: '-c 200 -m 90'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Description:**

In https://github.com/aws-observability/aws-otel-lambda/pull/169 we used .NET instead of Go because go was failing the integration tests. However, as of #174, Go has been fixed. Therefore, we use Go again for the release + soaking workflows.

Additionally, we enable the Canary tests. They were failing before because the Go Sample App was no working (the comment said it was because there was no published version but that's not true because Go simply uses the Collector Layer right now).

**Link to tracking Issue:** N/A

**Testing:** The integration tests passed for #174, so if the tests pass for Canary + Soaking + Release then we will be confident this change worked.

**Documentation:** Covered by the Collector Layer documentation.
