### PR TITLE
Lambda Layer Update - Synchronize Python 1.7.1 + Collector 0.39.0

### DIFF
--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -1,8 +1,8 @@
 cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 # replace collector with AOC
-go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.14.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.38.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.38.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.38.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.15.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.39.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.39.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.39.0
 go mod tidy


### PR DESCRIPTION
**Description:**

Take the latest changes which include Python 1.7.1 & Collector 0.39.0. Also, updates the Collector to use [ADOT Collector lambdacomponents tag v0.15.0](https://github.com/aws-observability/aws-otel-collector/releases/tag/pkg%2Flambdacomponents%2Fv0.15.0). This includes the OTel Collector at v0.39.0.

**Link to tracking Issue:**

N/A

**Testing:**

Covered by `main-build.yml` and `soaking.yml` and `canary.yml` tests that will run on merge.

**Documentation:**

To follow up on after successful release.

N/A
