### PR TITLE
Use correct terraform directory for go soak tests

### DIFF
--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -62,7 +62,7 @@ jobs:
             language: go
             build_directory: go
             build_command: ./build.sh
-            terraform_directory: integration-tests/go/aws-sdk/wrapper
+            terraform_directory: integration-tests/go/aws-sdk
             expected_trace_template: adot/utils/expected-templates/go-awssdk-wrapper.json
             soak_config: '-c 200 -m 90'
     steps:


### PR DESCRIPTION
**Description:**

Missed from #175, the folder for `go` is not the same as it is for `dotnet` and `java`, but it is the same as `nodejs` and `python`.

**Link to tracking Issue:**

N/A

**Testing:**

N/A

**Documentation:**

N/A
