### PR TITLE
Use environment variable to set release workflow soak test value

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,12 +196,13 @@ jobs:
       - name: Configure Collector Values
         if: ${{ github.event.inputs.layer_kind == 'collector' }}
         run: |-
-          echo "SAMPLE_APP_NAME=dotnet-awssdk-wrapper" >> $GITHUB_ENV;
-          echo "LANGUAGE=go" >> $GITHUB_ENV;
-          echo "BUILD_DIRECTORY=go" >> $GITHUB_ENV;
+          export TEST_LANGUAGE=go;
+          echo "SAMPLE_APP_NAME=$TEST_LANGUAGE-awssdk-wrapper" >> $GITHUB_ENV;
+          echo "LANGUAGE=$TEST_LANGUAGE" >> $GITHUB_ENV;
+          echo "BUILD_DIRECTORY=$TEST_LANGUAGE" >> $GITHUB_ENV;
           echo "BUILD_COMMAND=./build.sh" >> $GITHUB_ENV;
-          echo "TERRAFORM_DIRECTORY=sample-apps/go-wrapper-aws-sdk-terraform" >> $GITHUB_ENV;
-          echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/go-awssdk-wrapper.json" >> $GITHUB_ENV;
+          echo "TERRAFORM_DIRECTORY=sample-apps/$TEST_LANGUAGE-wrapper-aws-sdk-terraform" >> $GITHUB_ENV;
+          echo "EXPECTED_TRACE_TEMPLATE=adot/utils/expected-templates/$TEST_LANGUAGE-awssdk-wrapper.json" >> $GITHUB_ENV;
       - name: Set Configuration Outputs
         id: set-smoke-test-outputs
         run: |-


### PR DESCRIPTION
**Description:**

Once we saw [the release workflow Soak Tests for the Collector fail](https://github.com/aws-observability/aws-otel-lambda/runs/4304942821?check_suite_focus=true) we realized that we forgot to make the switch to go for one line in the workflow as part of #175.

This PR adds the correct value back and reduces the chance of error by pulling it out into an environment variable.

**Link to tracking Issue:**

N/A

**Testing:**

We won't know the success until the next release.

**Documentation:**

N/A
