### PR TITLE
Add ARM64 to Canary Workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -36,8 +36,7 @@ jobs:
         language: [ dotnet, go, java, nodejs, python ]
         sample-app: [ aws-sdk, okhttp ]
         instrumentation-type: [ agent, wrapper ]
-         # TODO: Add back arm64 when Lambda clock skew bug is fixed.
-        architecture: [ amd64 ]
+        architecture: [ amd64, arm64 ]
         exclude:
           - language: dotnet
             sample-app: okhttp


### PR DESCRIPTION
**Description:**

Blocked on #233

Follow up to #193, where we wanted to run Canary tests for ARM64 architecture but because of a Lambda clock skew we did not.

We did not to avoid having failing tests. When the issue is fixed, we **will release ARM Lambda Layers**. Once they are released, we can update the Canary tests with those ARNs and can merge this PR to continuously test those layers alongside the AMD ones.

**Link to tracking Issue:** N/A

**Testing:**

Covered by Canary Tests themselves.

**Documentation:** N/A
