### PR TITLE
Shorten Lambda Func Name to Less than 64 Chars

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -143,7 +143,7 @@ jobs:
         run: terraform apply -auto-approve
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}
         env:
-          TF_VAR_function_name: hello-lambda-${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{ github.run_id }}-${{ matrix.aws_region }}
+          TF_VAR_function_name: lambda-${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{ github.run_id }}-${{ matrix.aws_region }}
           TF_VAR_architecture: ${{ env.LAMBDA_FUNCTION_ARCH }}
       - name: Extract endpoint
         id: extract-endpoint

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -121,7 +121,7 @@ jobs:
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}
       - name: Get terraform Lambda function name
         run: |
-          echo TERRAFORM_LAMBDA_FUNCTION_NAME=hello-lambda-${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{ github.run_id }} |
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME=lambda-${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{ github.run_id }} |
           tee --append $GITHUB_ENV
       - name: Apply terraform
         run: terraform apply -auto-approve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,7 @@ jobs:
         run: terraform apply -auto-approve
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}
         env:
-          TF_VAR_function_name: hello-lambda-${{ env.TEST_LANGUAGE }}-aws-sdk-${{ env.TEST_INSTR_TYPE }}-${{ matrix.architecture }}-${{ github.run_id }}-${{ matrix.aws_region }}
+          TF_VAR_function_name: lambda-${{ env.TEST_LANGUAGE }}-aws-sdk-${{ env.TEST_INSTR_TYPE }}-${{ matrix.architecture }}-${{ github.run_id }}-${{ matrix.aws_region }}
           TF_VAR_architecture: ${{ env.LAMBDA_FUNCTION_ARCH }}
       - name: Extract endpoint
         id: extract-endpoint

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -155,7 +155,7 @@ jobs:
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}
       - name: Get terraform Lambda function name
         run: |
-          echo TERRAFORM_LAMBDA_FUNCTION_NAME=hello-lambda-${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{ github.run_id }} |
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME=lambda-${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{ github.run_id }} |
           tee --append $GITHUB_ENV
         # NOTE: (enowell) We don't need to include `sample-app` in the Lambda
         # Layer name because different apps should be use the same layer, not

--- a/adot/utils/expected-templates/dotnet-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/dotnet-aws-sdk-wrapper.json
@@ -1,15 +1,15 @@
 [
   {
-    "name":"hello-lambda-dotnet.*"
+    "name":"lambda-dotnet.*"
   },
   {
-    "name":"hello-lambda-dotnet.*"
+    "name":"lambda-dotnet.*"
   },
   {
-    "name":"hello-lambda-dotnet.*"
+    "name":"lambda-dotnet.*"
   },
   {
-    "name":"hello-lambda-dotnet.*"
+    "name":"lambda-dotnet.*"
   },
   {
     "name":"S3"

--- a/adot/utils/expected-templates/go-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/go-aws-sdk-wrapper.json
@@ -1,15 +1,15 @@
 [
   {
-    "name":"hello-lambda-go.*"
+    "name":"lambda-go.*"
   },
   {
-    "name":"hello-lambda-go.*"
+    "name":"lambda-go.*"
   },
   {
-    "name":"hello-lambda-go.*"
+    "name":"lambda-go.*"
   },
   {
-    "name":"hello-lambda-go.*"
+    "name":"lambda-go.*"
   },
   {
     "name":"S3",

--- a/adot/utils/expected-templates/java-aws-sdk-agent.json
+++ b/adot/utils/expected-templates/java-aws-sdk-agent.json
@@ -1,15 +1,15 @@
 [
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
     "name":"S3",

--- a/adot/utils/expected-templates/java-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/java-aws-sdk-wrapper.json
@@ -1,15 +1,15 @@
 [
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
     "name":"S3",

--- a/adot/utils/expected-templates/java-okhttp-wrapper.json
+++ b/adot/utils/expected-templates/java-okhttp-wrapper.json
@@ -1,15 +1,15 @@
 [
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
-    "name":"hello-lambda-java.*"
+    "name":"lambda-java.*"
   },
   {
     "name":"aws.amazon.com"

--- a/adot/utils/expected-templates/nodejs-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/nodejs-aws-sdk-wrapper.json
@@ -1,15 +1,15 @@
 [
   {
-    "name": "hello-lambda-nodejs.*"
+    "name": "lambda-nodejs.*"
   },
   {
-    "name": "hello-lambda-nodejs.*"
+    "name": "lambda-nodejs.*"
   },
   {
-    "name": "hello-lambda-nodejs.*"
+    "name": "lambda-nodejs.*"
   },
   {
-    "name": "hello-lambda-nodejs.*"
+    "name": "lambda-nodejs.*"
   },
   {
     "name": "s3"

--- a/adot/utils/expected-templates/python-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/python-aws-sdk-wrapper.json
@@ -1,15 +1,15 @@
 [
   {
-    "name":"hello-lambda-python.*"
+    "name":"lambda-python.*"
   },
   {
-    "name":"hello-lambda-python.*"
+    "name":"lambda-python.*"
   },
   {
-    "name":"hello-lambda-python.*"
+    "name":"lambda-python.*"
   },
   {
-    "name":"hello-lambda-python.*",
+    "name":"lambda-python.*",
     "subsegments": [
       {
           "name": "HTTP GET"

--- a/dotnet/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/dotnet/integration-tests/aws-sdk/wrapper/variables.tf
@@ -7,7 +7,7 @@ variable "collector_layer_name" {
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-dotnet-awssdk-wrapper"
+  default     = "lambda-dotnet-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/dotnet/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/dotnet/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -1,7 +1,7 @@
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-dotnet-awssdk-wrapper"
+  default     = "lambda-dotnet-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/go/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/go/integration-tests/aws-sdk/wrapper/variables.tf
@@ -7,7 +7,7 @@ variable "collector_layer_name" {
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-go-awssdk-wrapper"
+  default     = "lambda-go-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/go/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/go/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -1,7 +1,7 @@
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-go-awssdk-wrapper"
+  default     = "lambda-go-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/java/integration-tests/aws-sdk/agent/variables.tf
+++ b/java/integration-tests/aws-sdk/agent/variables.tf
@@ -19,7 +19,7 @@ variable "collector_config_layer_name" {
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-java-awssdk-agent"
+  default     = "lambda-java-awssdk-agent-amd64"
 }
 
 variable "architecture" {

--- a/java/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/java/integration-tests/aws-sdk/wrapper/variables.tf
@@ -13,7 +13,7 @@ variable "sdk_layer_name" {
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-java-awssdk-wrapper"
+  default     = "lambda-java-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/java/integration-tests/okhttp/wrapper/variables.tf
+++ b/java/integration-tests/okhttp/wrapper/variables.tf
@@ -13,7 +13,7 @@ variable "sdk_layer_name" {
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-java-okhttp-wrapper"
+  default     = "lambda-java-okhttp-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/java/sample-apps/aws-sdk/deploy/agent/variables.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/variables.tf
@@ -1,7 +1,7 @@
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-java-awssdk-agent"
+  default     = "lambda-java-awssdk-agent-amd64"
 }
 
 variable "architecture" {

--- a/java/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/java/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -1,7 +1,7 @@
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-java-awssdk-wrapper"
+  default     = "lambda-java-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/java/sample-apps/okhttp/deploy/wrapper/variables.tf
+++ b/java/sample-apps/okhttp/deploy/wrapper/variables.tf
@@ -1,7 +1,7 @@
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-java-okhttp-wrapper"
+  default     = "lambda-java-okhttp-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/nodejs/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/variables.tf
@@ -13,7 +13,7 @@ variable "sdk_layer_name" {
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-nodejs-awssdk"
+  default     = "lambda-nodejs-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -1,7 +1,7 @@
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-nodejs-awssdk"
+  default     = "lambda-nodejs-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/python/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/python/integration-tests/aws-sdk/wrapper/variables.tf
@@ -13,7 +13,7 @@ variable "sdk_layer_name" {
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-python-awssdk"
+  default     = "lambda-python-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {

--- a/python/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/python/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -1,7 +1,7 @@
 variable "function_name" {
   type        = string
   description = "Name of sample app function / API gateway"
-  default     = "hello-python-awssdk"
+  default     = "lambda-python-awssdk-wrapper-amd64"
 }
 
 variable "architecture" {


### PR DESCRIPTION
**Description:**

After merging #193, the Lambda functions include the `architecture` value in the Lambda function name. This is necessary so we can run both `amd64` and `arm64` Lambda's in parallel without name conflicts.

However, after this [the Canary Test started failing](https://github.com/aws-observability/aws-otel-lambda/runs/4956870271?check_suite_focus=true#step:19:19) because the name of the Lambda functions was greater than 64 characters. Both the Lambda function and IAM role created automatically by Terraform need to be within the 64 char limit.

To fix this, we reduce the name by removing the `hello-` prefix. We update all the testing templates, and update the defaults while we are at it.

**Link to tracking Issue:** N/A

**Testing:**

The Canary Tests pass for all the other Lambdas where their functions names are short enough. That gives us confidence that this slight change shouldn't change too much and hopefully just turn all the other tests green.

**Documentation:** N/A
