### PR TITLE
Do not partial match cache keys for Java Deps

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -79,8 +79,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - uses: actions/setup-node@v2
         if: ${{ matrix.language == 'nodejs' }}
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -78,7 +78,7 @@ jobs:
             ~/go/pkg/mod
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}-CACHE_VERSION=1
       - uses: actions/setup-node@v2
         if: ${{ matrix.language == 'nodejs' }}
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -53,7 +53,7 @@ jobs:
             ~/go/pkg/mod
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}-CACHE_VERSION=1
       - uses: actions/setup-node@v2
         if: ${{ matrix.language == 'nodejs' }}
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -54,8 +54,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - uses: actions/setup-node@v2
         if: ${{ matrix.language == 'nodejs' }}
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,8 +34,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - uses: actions/setup-node@v2
         if: ${{ matrix.language == 'nodejs' }}
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,7 +33,7 @@ jobs:
             ~/go/pkg/mod
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}-CACHE_VERSION=1
       - uses: actions/setup-node@v2
         if: ${{ matrix.language == 'nodejs' }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - uses: actions/setup-node@v2
         if: ${{ env.TEST_LANGUAGE == 'nodejs' }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,7 @@ jobs:
             ~/go/pkg/mod
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}-CACHE_VERSION=1
       - uses: actions/setup-node@v2
         if: ${{ env.TEST_LANGUAGE == 'nodejs' }}
         with:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -77,7 +77,7 @@ jobs:
             ~/go/pkg/mod
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}-CACHE_VERSION=1
       - name: Get default soaking test configuration
         if: ${{ matrix.language != 'java' }}
         run: |

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -78,8 +78,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Get default soaking test configuration
         if: ${{ matrix.language != 'java' }}
         run: |


### PR DESCRIPTION
## Description

Even though we merged #213, we still [see the main tests for the Java Wrapper failing](https://github.com/aws-observability/aws-otel-lambda/runs/5012481753?check_suite_focus=true).

I went into the AWS account and noticed that the Lambda function still has the same error we supposedly fixed in #213!

```
{
  "errorMessage": "Error loading class io.opentelemetry.instrumentation.awslambda.v1_0.TracingRequestApiGatewayWrapper: com/fasterxml/jackson/databind/ObjectMapper",
  "errorType": "java.lang.NoClassDefFoundError"
}
```

This means the fix was not applied. I looked at the Main Build workflow and noticed that the Java dependencies are cached.

The cache key is on `**/*.gradle*` files which is correct because those decide the dependencies.

However, the GitHub action also has this specified:

```yaml
restore-keys: |
    ${{ runner.os }}-gradle-
```

It was hard to find documentation, but I found [this comment on the GitHub workflow community forum](https://github.community/t/understanding-cache-action-keys/17503):

> If you provide restore-keys, the cache action sequentially searches for any caches that match the list of restore-keys.
> 1. When there is an exact match, the action restores the files in the cache to the path directory.
> 2. If there are no exact matches, the action searches for partial matches of the restore keys. When the action finds a partial match, the most recent cache is restored to the path directory.

The key part is this: **If there are no exact matches...When the action finds a partial match, the most recent cache is restored to the path directory.**.

I'm worried this means we are using the old cache. So, we will try remove this key **in every workflow**. We will still have caching but we will be more strict about exact matching when restoring cache. Otherwise we will take the hit and install the dependencies again.

Finally, we add a `CACHE_VERSION=1` because we are suspicious that the last failed run has created an invalid entry in the cache and we won't be able to test these changes.
