### PR TITLE
Lambda Layer Update Feb - Collector 0.45.0 + Java 1.11.1

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -24,8 +24,8 @@ spotless {
 }
 
 dependencies {
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.10.1"))
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.10.1-alpha"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.11.0"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.11.0-alpha"))
     // Already included in wrapper so compileOnly
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-aws")

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -18,12 +18,12 @@ cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 
 # Replace OTel Collector with ADOT Collector
-go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.16.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.17.0
 
 # Include X-Ray components for the Collector
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.43.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.43.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.43.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.45.1
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.45.1
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.45.1
 
 # A simple `go mod tidy` does not work.
 # See: https://github.com/aws-observability/aws-otel-collector/issues/926


### PR DESCRIPTION
**Description:** 

This PR updates the following
  * Update collector-contrib components to `V0.45.1` in `patch-upstream.sh`
  * Updated opentelemetry-lambda submodule to include latest changes
  * Java update OTel 1.11.1



