### PR TITLE
Update go version to 1.17.7

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -64,7 +64,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17'
+          go-version: '^1.17.7'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.17.7'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.17.7'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
         # above, always setup go 1.17.
         # if: ${{ env.TEST_LANGUAGE == 'go' }}
         with:
-          go-version: '^1.17'
+          go-version: '^1.17.7'
       - name: download layer tf file
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -63,7 +63,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.17.7'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:


### PR DESCRIPTION
**Description:** 

This PR updates the go version in `main-build.yml` and `release.yml` to mitigate [CVE-2022-23806](https://nvd.nist.gov/vuln/detail/CVE-2022-23806) .

Details related to CVE below

```
From: https://nvd.nist.gov/vuln/detail/CVE-2022-23806

Go Version Used in image: go version 1.17.6
Curve.IsOnCurve in crypto/elliptic in Go before 1.16.14 and 1.17.x before 1.17.7 can incorrectly return true in situations with a big.Int value that is not a valid field element ```
