### PR TITLE
Update Soak test script to include LambdaInsightsExtension for ARM64

### DIFF
--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -235,8 +235,9 @@ jobs:
           cd test-framework
           ./gradlew :validator:run --args="-c prometheus-static-metric-validation.yml --cortex-instance-endpoint ${{ steps.extract-amp-endpoint.outputs.stdout }} --region ${{ env.AWS_DEFAULT_REGION }}"
       - name: Run soak test
-        run: >-
-          docker run 
+        run:
+          >-
+            docker run
             --rm
             -e AWS_DEFAULT_REGION
             -e AWS_ACCESS_KEY_ID

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -246,7 +246,8 @@ jobs:
             public.ecr.aws/aws-otel-test/lambda-soak:latest
             -n ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}
             -e ${{ steps.extract-endpoint.outputs.stdout }}
-            ${{ github.event.inputs.soak_config }} ${{ env.SOAKING_TEST_CONFIG }}
+            ${{ github.event.inputs.soak_config }}
+            ${{ env.SOAKING_TEST_CONFIG }}
             -a ${{ matrix.architecture }}
       - name: Set output if layer Soak Tests has error
         id: set-layer-if-error-output

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -235,10 +235,18 @@ jobs:
           cd test-framework
           ./gradlew :validator:run --args="-c prometheus-static-metric-validation.yml --cortex-instance-endpoint ${{ steps.extract-amp-endpoint.outputs.stdout }} --region ${{ env.AWS_DEFAULT_REGION }}"
       - name: Run soak test
-        run: |
-          docker run --rm -e AWS_DEFAULT_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
-            public.ecr.aws/aws-otel-test/lambda-soak:latest -n ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }} \
-            -e ${{ steps.extract-endpoint.outputs.stdout }} ${{ github.event.inputs.soak_config }} ${{ env.SOAKING_TEST_CONFIG }}
+        run: >-
+          docker run 
+            --rm
+            -e AWS_DEFAULT_REGION
+            -e AWS_ACCESS_KEY_ID
+            -e AWS_SECRET_ACCESS_KEY
+            -e AWS_SESSION_TOKEN
+            public.ecr.aws/aws-otel-test/lambda-soak:latest
+            -n ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}
+            -e ${{ steps.extract-endpoint.outputs.stdout }}
+            ${{ github.event.inputs.soak_config }} ${{ env.SOAKING_TEST_CONFIG }}
+            -a ${{ matrix.architecture }}
       - name: Set output if layer Soak Tests has error
         id: set-layer-if-error-output
         if: ${{ failure() }}

--- a/adot/utils/soak/soak.py
+++ b/adot/utils/soak/soak.py
@@ -10,24 +10,26 @@ import requests
 state = False
 
 # LambdaInsight layer ARNs, suppose we run soak test only in these regions
-lambdaInsightArnMap = {}
-lambdaInsightArnMap[
-    "us-east-1"
-] = "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:14"
-lambdaInsightArnMap[
-    "us-east-2"
-] = "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:14"
-lambdaInsightArnMap[
-    "us-west-1"
-] = "arn:aws:lambda:us-west-1:580247275435:layer:LambdaInsightsExtension:14"
-lambdaInsightArnMap[
-    "us-west-2"
-] = "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:14"
+# ARM64 layers ARNs for us-west-1 are not available at the time of creating this PR
+# TODO (pvasir) Add the layer ARNs for us-west-1 in both AMD and ARM64 when cloudwatch-agent publish
+lambdaInsightAMD64ArnMap = {
+    "us-east-1": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:16",
+    "us-east-2": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension:16",
+    "us-west-2": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension:16"
+}
+lambdaInsightARM64ArnMap = {
+    "us-east-1": "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension-Arm64:1",
+    "us-east-2": "arn:aws:lambda:us-east-2:580247275435:layer:LambdaInsightsExtension-Arm64:1",
+    "us-west-2": "arn:aws:lambda:us-west-2:580247275435:layer:LambdaInsightsExtension-Arm64:1"
+}
+lambdaInsightsArchitectureMap = {
+    "amd64": lambdaInsightAMD64ArnMap,
+    "arm64": lambdaInsightARM64ArnMap
+}
 
-
-def enableLambdaInsight(function_name):
+def enableLambdaInsight(function_name, architecture):
     lambdaClient = boto3.client("lambda")
-    lambdaInsightLayerArn = lambdaInsightArnMap[boto3.Session().region_name]
+    lambdaInsightLayerArn = lambdaInsightsArchitectureMap[architecture][boto3.Session().region_name]
     response = lambdaClient.get_function_configuration(FunctionName=function_name)
     print("Lambda function has layers: {}".format(response["Layers"]))
 
@@ -51,7 +53,7 @@ def parse_args():
     # default setting
     _soaking_time, _emitter_interval, _cpu_threshold, _memory_threshold = 10000, 5, 60, 45
     argument_list = sys.argv[1:]
-    short_options = "i:t:e:n:c:m:"
+    short_options = "i:t:e:n:c:m:a:"
     long_options = [
         "interval=",
         "time=",
@@ -59,6 +61,7 @@ def parse_args():
         "name=",
         "cpu-threshold=",
         "memory-threshold=",
+        "architecture=",
     ]
 
     try:
@@ -80,6 +83,8 @@ def parse_args():
             _cpu_threshold = int(current_value)
         elif current_argument in ("-m", "--memory-threshold"):
             _memory_threshold = int(current_value)
+        elif current_argument in ("-a", "--architecture"):
+            _architecture = current_value
 
     print(
         (
@@ -89,6 +94,7 @@ def parse_args():
             "invoke interval:\t%s sec\n"
             "alarm cpu threshold:\t%s ns\n"
             "alarm memory threshold:\t%s%%"
+            "architecture:\t%s%%"
         )
         % (
             _name,
@@ -97,6 +103,7 @@ def parse_args():
             _emitter_interval,
             _cpu_threshold,
             _memory_threshold,
+            _architecture,
         )
     )
 
@@ -107,6 +114,7 @@ def parse_args():
         _emitter_interval,
         _cpu_threshold,
         _memory_threshold,
+        _architecture,
     )
 
 
@@ -182,10 +190,11 @@ if __name__ == "__main__":
         emitter_interval,
         cpu_threshold,
         memory_threshold,
+        architecture,
     ) = parse_args()
 
     # Enable LambdaInsight
-    enableLambdaInsight(function_name)
+    enableLambdaInsight(function_name, architecture)
 
     # Set alarm name
     memory_alarm = "otel_lambda_memory-" + function_name


### PR DESCRIPTION
**Description:** 

Currently the soak test scripts add lambda insights extensions from CloudWatch Agent to the lambda layer. the existing script adds the amd64 layers by default to both `amd` and `arm64` layers and hence the soak tests in `arm64` layers facing errors `{"message": "Internal server error"}`

This PR add the  script to select ARN's based on the architecture.

**Testing:** 

Testing is done locally with the docker command

```        
docker run --rm \
-v ~/.aws:/root/.aws \
lambdatest:latest \
-n lambda-test \
-e <end-point url> \
-t 1800 -c 90 -m 70 -a arm64
            
```

