### PR TITLE
Raise ARM64 Soak Test Limits

### DIFF
--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       soak_config:
         description: 'set memory/cpu threshold, soak time (s), emitter interval'
-        retuired: false
+        required: false
         default: '-t 1800'
 
 jobs:
@@ -81,12 +81,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Get default soaking test configuration
-        if: ${{ matrix.language != 'java' }}
+        if: ${{ matrix.language != 'java' && matrix.architecture != 'arm64' }}
         run: |
           echo SOAKING_TEST_CONFIG="-c 90 -m 70" | tee --append $GITHUB_ENV
       - name: Get java soaking test configuration
         # NOTE (enowell): Java's JVM is heavy and needs more memory than others.
-        if: ${{ matrix.language == 'java' }}
+        if: ${{ matrix.language == 'java' || matrix.architecture == 'arm64' }}
         run: |
           echo SOAKING_TEST_CONFIG="-c 200 -m 90" | tee --append $GITHUB_ENV
       - uses: actions/setup-node@v2

--- a/adot/utils/soak/soak.py
+++ b/adot/utils/soak/soak.py
@@ -174,7 +174,7 @@ def alarm_puller(function_name, cpu_threshold, memory_threshold):
     while True:
         for response in paginator.paginate(AlarmNames=[memory_alarm, cpu_alarm]):
             for alarm in response["MetricAlarms"]:
-                print("{} state {}".format(alarm["AlarmName"], alarm["StateValue"]))
+                print("{} state {} - {}".format(alarm["AlarmName"], alarm["StateValue"], alarm["StateReason"]))
                 if alarm["StateValue"] == "ALARM":
                     state = True
                     return


### PR DESCRIPTION
## Description

In [the most recent Soak Tests](https://github.com/aws-observability/aws-otel-lambda/runs/5419259972?check_suite_focus=true#step:35:251), we saw the Soak Tests catch high CPU usage in the ARM64 Lambda Layers. As such, we need to raise the thresholds for them. This PR also adds more helpful logging for the CloudWatch Alarms.