### PR TITLE
Raise Threshold limits for the soak tests

### DIFF
--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Get default soaking test configuration
         if: ${{ matrix.language != 'java' && matrix.architecture != 'arm64' }}
         run: |
-          echo SOAKING_TEST_CONFIG="-c 90 -m 70" | tee --append $GITHUB_ENV
+          echo SOAKING_TEST_CONFIG="-c 120 -m 90" | tee --append $GITHUB_ENV
       - name: Get java soaking test configuration
         # NOTE (enowell): Java's JVM is heavy and needs more memory than others.
         if: ${{ matrix.language == 'java' || matrix.architecture == 'arm64' }}

--- a/adot/utils/soak/soak.py
+++ b/adot/utils/soak/soak.py
@@ -93,8 +93,8 @@ def parse_args():
             "soak time:\t%s sec\n"
             "invoke interval:\t%s sec\n"
             "alarm cpu threshold:\t%s ns\n"
-            "alarm memory threshold:\t%s%%"
-            "architecture:\t%s%%"
+            "alarm memory threshold:\t%s%%\n"
+            "architecture:\t%s"
         )
         % (
             _name,


### PR DESCRIPTION
**Description:** Currently the soak tests are [failing](https://github.com/aws-observability/aws-otel-lambda/runs/5817696514?check_suite_focus=true#step:35:1709) as they are meeting the threshold This PR raises the threshold for Soak tests, corrects the small typo in the `print` statement
