### PR TITLE
Update Python3.9 and submodule with relevant changes

### DIFF
--- a/.github/workflows/main-build-python38.yml
+++ b/.github/workflows/main-build-python38.yml
@@ -1,0 +1,93 @@
+name: Python38 Layer Integration Test
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-20.04
+    name: Python38-${{ matrix.architecture }}-IntegrationTest
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: [ amd64, arm64 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.7'
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-duration-seconds: 1200
+          aws-region: us-east-1
+      - name: Patch ADOT
+        run: ./patch-upstream.sh
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+      - name: Build layers / functions
+        run: GOARCH=${{ matrix.architecture }} ./build.sh
+        working-directory: python
+      - name: Get Lambda Layer amd64 architecture value
+        if: ${{ matrix.architecture == 'amd64' }}
+        run: echo LAMBDA_FUNCTION_ARCH=x86_64 | tee --append $GITHUB_ENV
+      - name: Get Lambda Layer arm64 architecture value
+        if: ${{ matrix.architecture == 'arm64' }}
+        run: echo LAMBDA_FUNCTION_ARCH=arm64 | tee --append $GITHUB_ENV
+      - name: Get terraform directory
+        run: |
+          echo TERRAFORM_DIRECTORY=python/integration-tests/aws-sdk/wrapper |
+          tee --append $GITHUB_ENV
+      - uses: hashicorp/setup-terraform@v1
+      - name: Initialize terraform
+        run: terraform init
+        working-directory: ${{ env.TERRAFORM_DIRECTORY }}
+      - name: Get terraform Lambda function name
+        run: |
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME=lambda-python-${{ matrix.architecture }} |
+          tee --append $GITHUB_ENV
+      - name: Apply terraform
+        run: terraform apply -auto-approve
+        working-directory: ${{ env.TERRAFORM_DIRECTORY }}
+        env:
+          TF_VAR_sdk_layer_name: opentelemetry-python-aws-sdk-wrapper-${{ matrix.architecture }}
+          TF_VAR_function_name: ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}
+          TF_VAR_architecture: ${{ env.LAMBDA_FUNCTION_ARCH }}
+          TF_VAR_runtime: 'python3.8'
+      - name: Extract endpoint
+        id: extract-endpoint
+        run: terraform output -raw api-gateway-url
+        working-directory: ${{ env.TERRAFORM_DIRECTORY }}
+      - name: Extract SDK layer arn
+        id: extract-sdk-layer-arn
+        run: terraform output -raw sdk-layer-arn
+        working-directory: ${{ env.TERRAFORM_DIRECTORY }}
+      - name: Output annotations
+        run: |
+          echo "::warning::Function: ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}"
+          echo "::warning::SDK Layer ARN: ${{ steps.extract-sdk-layer-arn.outputs.stdout }}"
+      - name: Send request to endpoint
+        run: curl -sS ${{ steps.extract-endpoint.outputs.stdout }}
+      - name: Checkout test framework
+        uses: actions/checkout@v2
+        with:
+          repository: aws-observability/aws-otel-test-framework
+          path: test-framework
+      - name: validate trace sample
+        run: |
+          cp adot/utils/expected-templates/python-aws-sdk-wrapper.json \
+             test-framework/validator/src/main/resources/expected-data-template/lambdaExpectedTrace.mustache
+          cd test-framework
+          ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
+      - name: Destroy terraform
+        if: always()
+        run: terraform destroy -auto-approve
+        working-directory: ${{ env.TERRAFORM_DIRECTORY }}

--- a/.github/workflows/main-build-python38.yml
+++ b/.github/workflows/main-build-python38.yml
@@ -1,5 +1,5 @@
 name: Python38 Layer Integration Test
-
+# This workflow is for verifying python3.9 layer in Lambda python3.8 environment
 on:
   push:
     branches: [ main ]

--- a/adot/python/src/template.yml
+++ b/adot/python/src/template.yml
@@ -1,20 +1,21 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
-Description: OpenTelemetry Python Lambda layer for Python 3.8 Runtime
+Description: OpenTelemetry Python Lambda layer for Python
 Parameters:
   LayerName:
     Type: String
     Description: Lambda layer name to be published
-    Default: adot-opentelemetry-python-38
+    Default: adot-opentelemetry-python
 Resources:
   OTelLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:
       LayerName: !Ref LayerName
-      Description: Opentelemetry Python38 layer
+      Description: Opentelemetry Python layer
       ContentUri: ./otel
       CompatibleRuntimes:
         - python3.8
+        - python3.9
     Metadata:
       BuildMethod: makefile
   api:
@@ -27,7 +28,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: lambda_function.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.9
       CodeUri: ./function
       Description: Build ADOT Python Lambda layer and sample app from scratch
       MemorySize: 512

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -5,6 +5,7 @@ module "test" {
   sdk_layer_name         = var.sdk_layer_name
   function_name          = var.function_name
   architecture           = var.architecture
+  runtime                = var.runtime
 
   tracing_mode = "Active"
 }

--- a/python/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/python/integration-tests/aws-sdk/wrapper/variables.tf
@@ -21,3 +21,9 @@ variable "architecture" {
   description = "Lambda function architecture, either arm64 or x86_64"
   default     = "x86_64"
 }
+
+variable "runtime" {
+  type        = string
+  description = "Python runtime version used for sample Lambda Function"
+  default     = "python3.9"
+}

--- a/python/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/python/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -15,6 +15,7 @@ module "app" {
   sdk_layer_arn       = local.architecture_to_arns_mapping[var.architecture][data.aws_region.current.name]
   tracing_mode        = "Active"
   architecture        = var.architecture
+  runtime             =var.runtime
 }
 
 resource "aws_iam_role_policy_attachment" "test_xray" {

--- a/python/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/python/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -9,3 +9,9 @@ variable "architecture" {
   description = "Lambda function architecture, either arm64 or x86_64"
   default     = "x86_64"
 }
+
+variable "runtime" {
+  type        = string
+  description = "Python runtime version used for sample Lambda Function"
+  default     = "python3.9"
+}


### PR DESCRIPTION
**Description:** 
This PR updates the submodules and makes relevant changes to support python3.9.

`main-build-python3.8.yml` This workflow is for verifying python3.9 layer in Lambda python3.8 environment

**Link to tracking Issue:** 
 * https://github.com/aws-observability/aws-otel-lambda/issues/222

**Testing:** 

Performed testing on [local fork](https://github.com/vasireddy99/aws-otel-lambda/actions/runs/2094336051)
