### PR TITLE
Use team for codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @anuraaga @wangzlei
+* @aws-observability/adot-sdk-maintainers


### PR DESCRIPTION
In the future perhaps there is a more appropriate team for this (ideally a lambda team with lambda engineers on it ;) ), but in the meantime it definitely shouldn't have me listed explicitly on it.