### PR TITLE
Use Sigv4 Authentication for Prometheus Remote Write exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-# To be Released
-
-
 ## 2022-05-23 Release
 **AWS Distro For OpenTelemetry Lambda now supports ARM64 Architecture**
 - Python layer [**aws-otel-python-<amd64|arm64>-ver-1-11-1**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.11.1` with the AWS Python Extension `v2.0.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+# To be Released
+
+
 ## 2022-05-23 Release
 **AWS Distro For OpenTelemetry Lambda now supports ARM64 Architecture**
 - Python layer [**aws-otel-python-<amd64|arm64>-ver-1-11-1**](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python) contains OpenTelemetry Python `v1.11.1` with the AWS Python Extension `v2.0.1`

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -23,7 +23,7 @@ data "archive_file" "init" {
     content  = <<EOT
 extensions:
   sigv4auth:
-    region: "us-west-2"
+    region: ${data.aws_region.current.name}
 
 receivers:
   otlp:

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -40,7 +40,7 @@ data "archive_file" "init" {
     content  = <<EOT
 extensions:
   sigv4auth:
-    region: "us-west-2"
+    region: ${data.aws_region.current.name}
 
 receivers:
   otlp:

--- a/java/sample-apps/aws-sdk/deploy/agent/main.tf
+++ b/java/sample-apps/aws-sdk/deploy/agent/main.tf
@@ -38,6 +38,10 @@ data "archive_file" "init" {
   depends_on = [aws_prometheus_workspace.test_amp_workspace[0], data.aws_region.current]
   source {
     content  = <<EOT
+extensions:
+  sigv4auth:
+    region: "us-west-2"
+
 receivers:
   otlp:
     protocols:
@@ -47,20 +51,20 @@ receivers:
 exporters:
   logging:
   awsxray:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: "${aws_prometheus_workspace.test_amp_workspace[0].prometheus_endpoint}api/v1/remote_write"
-    aws_auth:
-      service: "aps"
-      region: "${data.aws_region.current.name}"
+    auth:
+      authenticator: sigv4auth
 
 service:
+  extensions: [sigv4auth]
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]
 EOT
     filename = "config.yaml"
   }


### PR DESCRIPTION
**Description:** 

This PR uses SIgV4 authentication for Prometheus remote write exporter, the current aws prometheus write exporter is expected to be deprecated in the near future.


Reference:  [Blog Post](https://aws-otel.github.io/docs/sigv4)


**Documentation:** < Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
