### PR TITLE
Use OpenTelemetry Java Agent to replace ADOT Java Agent

### DIFF
--- a/adot/utils/expected-templates/java-aws-sdk-agent.json
+++ b/adot/utils/expected-templates/java-aws-sdk-agent.json
@@ -12,6 +12,12 @@
     "name":"lambda-java.*"
   },
   {
+    "name":"lambda-java.*"
+  },
+  {
+    "name":"lambda-java.*"
+  },
+  {
     "name":"S3",
     "origin":"AWS::S3",
     "inferred":true,

--- a/java/build.sh
+++ b/java/build.sh
@@ -19,9 +19,9 @@ cp ./build/libs/aws-otel-lambda-java-extensions.jar ../opentelemetry-lambda/java
 # Go to OTel Lambda Java folder
 cd ../opentelemetry-lambda/java || exit
 
-# Build the OTel Lambda Java folder which has ADOT Lambda Java configured code
-OTEL_VERSION=1.10.1
-./gradlew build -Potel.lambda.javaagent.dependency=software.amazon.opentelemetry:aws-opentelemetry-agent:$OTEL_VERSION
+# Build the OTel Lambda Java
+OTEL_VERSION=1.14.0
+./gradlew build -Potel.lambda.javaagent.dependency=io.opentelemetry.javaagent:opentelemetry-javaagent:$OTEL_VERSION
 
 # Combine Java Agent build and ADOT Collector
 pushd ./layer-javaagent/build/distributions || exit


### PR DESCRIPTION
**Description:**

This PR makes the changes to use Upstream Java Agent, templates for the `integ-testing` accordingly


**Testing:** 

The testing was done locally and has verified the traces in `AWS- XRay` Console, and logs in `cloudwatch`.

More Context : The PR is made in the context to not be dependant on the ADOT Java Agent. As it would be a blocker for Lambda Layer Java Releases in such a case where release of ADOT Java Agent on hold. 

**Adding more Reviewers just to miss no context**

Traces :

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/41936996/174140434-55deb877-31fc-4076-b433-c9442631923c.png">

Metrics :

<img width="354" alt="image" src="https://user-images.githubusercontent.com/41936996/174140559-d12ec7d5-1a5c-46f8-a86c-e81d039a7bc6.png">


**Documentation:** < Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
