### PR TITLE
Update ADOT Java Agent to 1.14.0 - Lambda Layer Java Agent Update

### DIFF
--- a/java/build.sh
+++ b/java/build.sh
@@ -20,7 +20,7 @@ cp ./build/libs/aws-otel-lambda-java-extensions.jar ../opentelemetry-lambda/java
 cd ../opentelemetry-lambda/java || exit
 
 # Build the OTel Lambda Java folder which has ADOT Lambda Java configured code
-OTEL_VERSION=1.10.1
+OTEL_VERSION=1.14.0
 ./gradlew build -Potel.lambda.javaagent.dependency=software.amazon.opentelemetry:aws-opentelemetry-agent:$OTEL_VERSION
 
 # Combine Java Agent build and ADOT Collector


### PR DESCRIPTION
**Description:**

This PR Updates ADOT Java Agent to use latest `1.14.0`. This PR also serves the purpose to continue with the release next steps.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
