### PR TITLE
Update `Opentelemetry-lambda` submodule + NodeJS 1.4 + ADOT Java 1.15 + Collector 0.54

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -80,7 +80,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '^1.18'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/main-build-python38.yml
+++ b/.github/workflows/main-build-python38.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '^1.18'
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '^1.18'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '^1.18'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,7 @@ jobs:
         # above, always setup go 1.17.
         # if: ${{ env.TEST_LANGUAGE == 'go' }}
         with:
-          go-version: '^1.17.7'
+          go-version: '^1.18'
       - name: download layer tf file
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -63,7 +63,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.7'
+          go-version: '^1.18'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -24,8 +24,8 @@ spotless {
 }
 
 dependencies {
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.14.0"))
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.14.0-alpha"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.15.0"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.15.0-alpha"))
     // Already included in wrapper so compileOnly
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-aws")

--- a/java/build.sh
+++ b/java/build.sh
@@ -20,7 +20,7 @@ cp ./build/libs/aws-otel-lambda-java-extensions.jar ../opentelemetry-lambda/java
 cd ../opentelemetry-lambda/java || exit
 
 # Build the OTel Lambda Java folder which has ADOT Lambda Java configured code
-OTEL_VERSION=1.14.0
+OTEL_VERSION=1.15.0
 ./gradlew build -Potel.lambda.javaagent.dependency=software.amazon.opentelemetry:aws-opentelemetry-agent:$OTEL_VERSION
 
 # Combine Java Agent build and ADOT Collector

--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -26,22 +26,21 @@
   },
   "devDependencies": {
     "@types/node": "14.14.41",
-    "@typescript-eslint/eslint-plugin": "4.3.0",
-    "@typescript-eslint/parser": "4.3.0",
-    "eslint": "7.19.0",
-    "eslint-config-airbnb-base": "14.2.0",
+    "@typescript-eslint/eslint-plugin": "5.3.1",
+    "@typescript-eslint/parser": "5.3.1",
+    "eslint": "7.32.0",
     "eslint-plugin-header": "3.1.1",
-    "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-import": "2.26.0",
     "gts": "3.1.0",
     "rimraf": "3.0.2",
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.4",
-    "@opentelemetry/core": "^1.0.1",
-    "@opentelemetry/id-generator-aws-xray": "^1.0.1",
-    "@opentelemetry/sdk-trace-node": "^1.0.1",
-    "@opentelemetry/propagator-aws-xray": "^1.0.1",
-    "@opentelemetry/propagator-b3": "^1.0.1"
+    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/core": "^1.2.0",
+    "@opentelemetry/id-generator-aws-xray": "^1.1.0",
+    "@opentelemetry/sdk-trace-node": "^1.4.0",
+    "@opentelemetry/propagator-aws-xray": "^1.1.0",
+    "@opentelemetry/propagator-b3": "^1.2.0"
   }
 }

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -18,15 +18,14 @@ cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 
 # Replace OTel Collector with ADOT Collector
-go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.18.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.19.0
 
 # Include X-Ray components for the Collector
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.51.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.51.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.51.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.54.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.54.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.54.0
 
 # A simple `go mod tidy` does not work.
 # See: https://github.com/aws-observability/aws-otel-collector/issues/926
 rm -fr go.sum
-go mod tidy -go=1.16
-go mod tidy -go=1.17
+go mod tidy -go=1.18


### PR DESCRIPTION
**Description:** 

This PR updates the `OpenTelemetry-lambda` submodule which includes:
 * ADOT Java 1.15
 * Node JS 1.4
 * Collector 0.54, ADOT lambda components
 * Update Go version to `1.18.0`

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
