### PR TITLE
Update submodule, update JS deps and use go-1.17

### DIFF
--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -37,10 +37,10 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.1.0",
-    "@opentelemetry/core": "^1.2.0",
+    "@opentelemetry/core": "^1.4.0",
     "@opentelemetry/id-generator-aws-xray": "^1.1.0",
     "@opentelemetry/sdk-trace-node": "^1.4.0",
     "@opentelemetry/propagator-aws-xray": "^1.1.0",
-    "@opentelemetry/propagator-b3": "^1.2.0"
+    "@opentelemetry/propagator-b3": "^1.4.0"
   }
 }

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -28,4 +28,4 @@ go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/i
 # A simple `go mod tidy` does not work.
 # See: https://github.com/aws-observability/aws-otel-collector/issues/926
 rm -fr go.sum
-go mod tidy -go=1.18
+go mod tidy -compat=1.17


### PR DESCRIPTION
**Description:** 
Update submodule, update JS deps to latest and use go 1.17 in go.mod

references :

* https://github.com/open-telemetry/opentelemetry-js/pull/2895
* https://github.com/open-telemetry/opentelemetry-js/issues/2816#issuecomment-1090501716 - SIG Meeting reference
Use Go1.17 in go.mod to match with the opentelemetry-collector

* https://github.com/open-telemetry/opentelemetry-collector/blob/main/go.mod#L3
* Use go mod tidy compat=1.17
* https://github.com/open-telemetry/opentelemetry-collector/pull/4810

**Testing:** 
Local box

**Documentation:** < Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
