### PR TITLE
Fix global propagator registration

### DIFF
--- a/nodejs/build.sh
+++ b/nodejs/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 SOURCEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Build collector

--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -36,7 +36,6 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.1.0",
     "@opentelemetry/core": "^1.5.0",
     "@opentelemetry/id-generator-aws-xray": "^1.1.0",
     "@opentelemetry/sdk-trace-node": "^1.5.0",

--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -25,6 +25,7 @@
     "node": ">=10.0.0"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.1.0",
     "@types/node": "14.14.41",
     "@typescript-eslint/eslint-plugin": "5.3.1",
     "@typescript-eslint/parser": "5.3.1",

--- a/nodejs/wrapper-adot/src/adot-extension.ts
+++ b/nodejs/wrapper-adot/src/adot-extension.ts
@@ -1,25 +1,29 @@
-import { propagation } from '@opentelemetry/api';
 import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
+import { SDKRegistrationConfig } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerConfig } from '@opentelemetry/sdk-trace-node';
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { AWSXRayIdGenerator } from '@opentelemetry/id-generator-aws-xray';
 import { AWSXRayPropagator } from '@opentelemetry/propagator-aws-xray';
 
 declare global {
+  function configureSdkRegistration(defaultSdkRegistration: SDKRegistrationConfig): SDKRegistrationConfig;
   function configureTracer(defaultConfig: NodeTracerConfig): NodeTracerConfig;
 }
 
 if (!process.env.OTEL_PROPAGATORS) {
-  propagation.setGlobalPropagator(
-    new CompositePropagator({
-      propagators: [
-        new AWSXRayPropagator(),
-        new W3CTraceContextPropagator(),
-        new B3Propagator(),
-        new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
-      ],
-    })
-  );
+  global.configureSdkRegistration = (config: SDKRegistrationConfig) => {
+      return{
+        ...config,
+        propagator: new CompositePropagator({
+          propagators: [
+            new AWSXRayPropagator(),
+            new W3CTraceContextPropagator(),
+            new B3Propagator(),
+            new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
+          ],
+        }),
+      };
+  }
 }
 
 global.configureTracer = (config: NodeTracerConfig) => {


### PR DESCRIPTION
**Description:** Avoid duplicate registration errors by using the
`global.configureSdkRegistration()` callback to set
the `propagator` field of the `SDKRegistrationConfig`
rather than explicitly calling `propagation.setGlobalPropagator()`.

Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
