### PR TITLE
Update Opentelemetry-lambda submodule + NodeJS 1.6 + OTEl Python 1.12.0+ ADOT Java + ADOT collector -v0.21.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,8 +304,8 @@ jobs:
       - name: Use Go Language
         uses: actions/setup-go@v2
         # NOTE: (enowell) In case the languages below need to build the
-        # collector, and because building the collector requires go 1.17 and
-        # above, always setup go 1.17.
+        # collector, and because building the collector requires go 1.18 and
+        # above, always setup go 1.18.
         # if: ${{ env.TEST_LANGUAGE == 'go' }}
         with:
           go-version: '^1.18'

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -24,8 +24,8 @@ spotless {
 }
 
 dependencies {
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.16.0"))
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.16.0-alpha"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.17.0"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.17.0-alpha"))
     // Already included in wrapper so compileOnly
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-aws")

--- a/java/build.sh
+++ b/java/build.sh
@@ -20,7 +20,7 @@ cp ./build/libs/aws-otel-lambda-java-extensions.jar ../opentelemetry-lambda/java
 cd ../opentelemetry-lambda/java || exit
 
 # Build the OTel Lambda Java folder which has ADOT Lambda Java configured code
-OTEL_VERSION=1.16.0
+OTEL_VERSION=1.17.0
 ./gradlew build -Potel.lambda.javaagent.dependency=software.amazon.opentelemetry:aws-opentelemetry-agent:$OTEL_VERSION
 
 # Combine Java Agent build and ADOT Collector

--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -22,10 +22,10 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/api": "^1.2.0",
     "@types/node": "14.14.41",
     "@typescript-eslint/eslint-plugin": "5.3.1",
     "@typescript-eslint/parser": "5.3.1",
@@ -37,10 +37,10 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.5.0",
+    "@opentelemetry/core": "^1.6.0",
     "@opentelemetry/id-generator-aws-xray": "^1.1.0",
-    "@opentelemetry/sdk-trace-node": "^1.5.0",
+    "@opentelemetry/sdk-trace-node": "^1.6.0",
     "@opentelemetry/propagator-aws-xray": "^1.1.0",
-    "@opentelemetry/propagator-b3": "^1.5.0"
+    "@opentelemetry/propagator-b3": "^1.6.0"
   }
 }

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -18,14 +18,14 @@ cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 
 # Replace OTel Collector with ADOT Collector
-go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.20.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.21.0
 
 # Include X-Ray components for the Collector
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.56.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.56.0
-go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.56.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil@v0.58.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics@v0.58.0
+go mod edit -replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray=github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray@v0.58.0
 
 # A simple `go mod tidy` does not work.
 # See: https://github.com/aws-observability/aws-otel-collector/issues/926
 rm -fr go.sum
-go mod tidy -compat=1.17
+go mod tidy -compat=1.18


### PR DESCRIPTION
**Description:**

This PR update opentelemetry-lambda submodule. Also, aim to fix soak test and main-build workflows for python layer release as the current tests are failing atm.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
