### PR TITLE
Update aws-otel-lambda workflows 

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -78,9 +78,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19.1'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/main-build-python38.yml
+++ b/.github/workflows/main-build-python38.yml
@@ -2,7 +2,9 @@ name: Python38 Layer Integration Test
 # This workflow is for verifying python3.9 layer in Lambda python3.8 environment
 on:
   push:
-    branches: [ main ]
+    branches: 
+      - main 
+      - release/*
   workflow_dispatch:
 
 jobs:
@@ -17,9 +19,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19.1'
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -2,7 +2,9 @@ name: Main Build
 
 on:
   push:
-    branches: [ main ]
+    branches: 
+      - main 
+      - release/*
   workflow_dispatch:
 
 jobs:
@@ -37,9 +39,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19.1'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19.1'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,13 +302,13 @@ jobs:
       #   with:
       #     dotnet-version: '3.1.x'
       - name: Use Go Language
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         # NOTE: (enowell) In case the languages below need to build the
         # collector, and because building the collector requires go 1.18 and
         # above, always setup go 1.18.
         # if: ${{ env.TEST_LANGUAGE == 'go' }}
         with:
-          go-version: '^1.18'
+          go-version: '^1.19.1'
       - name: download layer tf file
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -61,9 +61,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19.1'
       - uses: actions/setup-java@v2
         if: ${{ matrix.language == 'java' }}
         with:


### PR DESCRIPTION
**Description:** 

This PR updates 

1. For all the workflows to use the `go v0.19.1`
2. Trigger [main-build.yml](https://github.com/aws-observability/aws-otel-lambda/compare/main...Kausik-A:go19?expand=1#diff-cadecc0b07db7b001692f19a091a0fe88e550e6c04d8eb279431ea93bc6fe35e) and [main-build-python38.yml](https://github.com/aws-observability/aws-otel-lambda/compare/main...Kausik-A:go19?expand=1#diff-01e5efb0e43730837618ab5bf3374347e21e0f75f7c00aaf753241b8ac828a02) on push of a `release/*` branch

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
