### PR TITLE
Reverting changes to python expected trace template 

### DIFF
--- a/adot/utils/expected-templates/python-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/python-aws-sdk-wrapper.json
@@ -24,15 +24,6 @@
     ]
   },
   {
-    "name":"HTTP GET"
-  },
-  {
-    "name":"HTTP GET"
-  },
-  {
-    "name":"HTTP GET"
-  },
-  {
     "name":"HTTP GET",
     "inferred":true,
     "http":{

--- a/adot/utils/expected-templates/python-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/python-aws-sdk-wrapper.json
@@ -27,6 +27,12 @@
     "name":"HTTP GET"
   },
   {
+    "name":"HTTP GET"
+  },
+  {
+    "name":"HTTP GET"
+  },
+  {
     "name":"HTTP GET",
     "inferred":true,
     "http":{


### PR DESCRIPTION
**Description:** 

This PR reverts the changes make in #287 and #286. After the [fix](https://github.com/open-telemetry/opentelemetry-lambda/pull/280) upstream we dont need the extra duplicate http spans created by [this](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1255) bug 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
