### PR TITLE
Fix relative paths for dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    directory: "/"
+    directory: "/java"
     schedule:
       interval: "weekly"
       day: sunday
@@ -10,10 +10,8 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"
-    directory: '/'
+    directory: "/nodejs/wrapper-adot"
     schedule:
       interval: "weekly"
       day: "sunday"
-    labels:
-      - "npm dependencies"
     rebase-strategy: "auto"


### PR DESCRIPTION
**Description:** Updates to point dependabot config to relative paths for package manifests. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
