### PR TITLE
Use success() condition in the soak workflow

### DIFF
--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -253,7 +253,7 @@ jobs:
             -a ${{ matrix.architecture }}
       - name: Set output if layer Soak Tests has error
         id: set-layer-if-error-output
-        if: ${{ failure() }}
+        if: ${{ success() }}
         run: echo "::set-output name=${{ matrix.language }}-${{ matrix.instrumentation-type }}-error::FAILED"
       - name: Remove sdk layers from terraform management to prevent deletion.
         if: ${{ matrix.language != 'go' }}

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -150,6 +150,8 @@ jobs:
           echo TERRAFORM_DIRECTORY=${{ matrix.language }}/integration-tests/${{ matrix.sample-app }}/${{ matrix.instrumentation-type }} |
           tee --append $GITHUB_ENV
       - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.3.1
       - name: Initialize terraform
         run: terraform init
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}


### PR DESCRIPTION
**Description:** 

This PR is created to use [success](https://docs.github.com/en/actions/learn-github-actions/expressions#success)s instead of failure(). The reason for this change is that it is not necessary to check the ancestors jobs.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
