### PR TITLE
Use us-west-2 region for publishing Github workflow metrics

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -193,7 +193,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           mask-aws-account-id: false
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
 
       - name: Publish CI status
         run: |

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -194,7 +194,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           mask-aws-account-id: false
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
 
       - name: Publish CI status
         run: |

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -310,7 +310,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           mask-aws-account-id: false
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          aws-region: us-west-2
 
       - name: Publish CI status
         run: |


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

**Description:** Use hard coded region for storing workflow metrics.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
