### PR TITLE
Use reusable workflow to publish status

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -183,27 +183,15 @@ jobs:
         run: terraform destroy -auto-approve
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}
   publish-canary-status:
-    runs-on: ubuntu-latest
     needs: [canary-test]
-    if: always()
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.METRICS_ROLE_ARN }}
-          aws-region: us-west-2
-          role-duration-seconds: 21600
-
-      - name: Publish CI status
-        run: |
-          if [ '${{ needs.canary-test.result }}' = 'success' ]; then
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=canary \
-              --value 1.0
-          else
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=canary \
-              --value 0.0
-          fi
+    if: ${{ always() }}
+    uses: ./.github/workflows/publish-status.yml
+    with:
+      namespace: 'ADOT/GitHubActions'
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      workflow: canary
+      success: ${{ needs.canary-test.result == 'success' }}
+      region: us-west-2
+    secrets:
+      roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -184,26 +184,15 @@ jobs:
         run: terraform destroy -auto-approve
         working-directory: ${{ env.TERRAFORM_DIRECTORY }}
   publish-build-status:
-    runs-on: ubuntu-latest
     needs: [integration-test]
-    if: always()
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.METRICS_ROLE_ARN }}
-          aws-region: us-west-2
-          role-duration-seconds: 21600
-      - name: Publish CI status
-        run: |
-          if [ '${{ needs.integration-test.result }}' = 'success' ]; then
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main-build \
-              --value 1.0
-          else
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main-build \
-              --value 0.0
-          fi
+    if: ${{ always() }}
+    uses: ./.github/workflows/publish-status.yml
+    with:
+      namespace: 'ADOT/GitHubActions'
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      workflow: main-build
+      success: ${{ needs.integration-test.result == 'success' }}
+      region: us-west-2
+    secrets:
+      roleArn: ${{ secrets.METRICS_ROLE_ARN }}

--- a/.github/workflows/publish-status.yml
+++ b/.github/workflows/publish-status.yml
@@ -1,0 +1,59 @@
+# Reusable workflow used to publish status of the caller github workflow to Cloudwatch metrics
+name: Publish status
+on:
+  workflow_call:
+    inputs:
+      # Cloudwatch Metrics namespace
+      namespace:
+        required: true
+        type: string
+      # Dimensions
+      repository:
+        required: true
+        type: string
+      branch:
+        require: true
+        type: string
+      workflow:
+        required: true
+        type: string
+      # Metric name
+      success:
+        required: true
+        type: boolean
+      # Region where the metric is published
+      region:
+        required: true
+        type: string
+    secrets:
+      roleArn:
+        required: true
+
+jobs:
+  publish-status:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.roleArn }}
+          aws-region: ${{ inputs.region }}
+          role-duration-seconds: 21600
+
+      - name: Publish status success
+        if: ${{ inputs.success }}
+        run: |
+          aws cloudwatch put-metric-data --namespace '${{ inputs.namespace }}' \
+            --metric-name Success \
+            --dimensions repository=${{ inputs.repository }},branch=${{ inputs.branch }},workflow=${{ inputs.workflow }} \
+            --value 1.0
+      - name: Publish status failure
+        if: ${{ !inputs.success }}
+        run: |
+          aws cloudwatch put-metric-data --namespace '${{ inputs.namespace }}' \
+            --metric-name Success \
+            --dimensions repository=${{ inputs.repository }},branch=${{ inputs.branch }},workflow=${{ inputs.workflow }} \
+            --value 0.0

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -300,27 +300,15 @@ jobs:
           echo "::warning::Layer ARN Keyword: arn:aws:lambda:${{ env.AWS_DEFAULT_REGION }}:611364707713:layer:aws-otel-${{ matrix.language }}-${{ matrix.instrumentation-type }}-<ARCHITECTURE>-${{ github.sha }}:$VERSION"
 
   publish-soaking-status:
-    runs-on: ubuntu-latest
     needs: [soaking-test]
-    if: always()
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          role-to-assume: ${{ secrets.METRICS_ROLE_ARN }}
-          aws-region: us-west-2
-          role-duration-seconds: 21600
-
-      - name: Publish CI status
-        run: |
-          if [ '${{ needs.soaking-test.result }}' = 'success' ]; then
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=soaking \
-              --value 1.0
-          else
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=soaking \
-              --value 0.0
-          fi
+    if: ${{ always() }}
+    uses: ./.github/workflows/publish-status.yml
+    with:
+      namespace: 'ADOT/GitHubActions'
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      workflow: soaking
+      success: ${{ needs.soaking-test.result == 'success' }}
+      region: us-west-2
+    secrets:
+      roleArn: ${{ secrets.METRICS_ROLE_ARN }}


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

**Description:** Use reusable workflow to publish status of other workflows. This will make it easier to have a central place for storing reusable workflows in the future as we will need to change just the name of the workflow while the parameters will remain the same.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
