### PR TITLE
Use GitHub OIDC provider for account auth

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -119,9 +119,7 @@ jobs:
         working-directory: ${{ matrix.language }}
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: ${{ matrix.aws_region }}
       - name: Get terraform directory

--- a/.github/workflows/docker-build-lambda-soak.yml
+++ b/.github/workflows/docker-build-lambda-soak.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: us-east-1
       - name: Login to ECR

--- a/.github/workflows/main-build-python38.yml
+++ b/.github/workflows/main-build-python38.yml
@@ -32,9 +32,7 @@ jobs:
           go-version: '^1.19.4'
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: us-east-1
       - name: Patch ADOT

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -100,9 +100,7 @@ jobs:
           dotnet-version: '3.1.x'
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: us-east-1
       - name: Patch ADOT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,7 @@ jobs:
       # switch to prod
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN_PROD }}
+          role-to-assume: ${{ secrets.PROD_LAMBDA_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: ${{ matrix.aws_region }}
           mask-aws-account-id: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,7 @@ jobs:
     steps:
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: us-east-1
       - name: Get layer ARN by substituting `${{ matrix.architecture }}` into Soak Test ARN keyword
@@ -296,9 +294,7 @@ jobs:
         working-directory: ${{ env.TEST_LANGUAGE }}
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: ${{ matrix.aws_region }}
       - uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -124,9 +124,7 @@ jobs:
       # Default session duration is 6 hours.
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}
           mask-aws-account-id: false
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Patch ADOT


### PR DESCRIPTION
**Description:** Switch to using IAM Roles with trust relationship with a GitHub OIDC Provider. Secrets must be created first. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
