### PR TITLE
Update cpu threshold for lambda soak tests.

### DIFF
--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -88,7 +88,7 @@ jobs:
         # CPU baseline was obtained empirically based on the max value observed for Go in a complete run of soak test
         if: ${{ matrix.language != 'java' }}
         run: |
-          echo SOAKING_TEST_CONFIG="-c 100 -m 70" | tee --append $GITHUB_ENV
+          echo SOAKING_TEST_CONFIG="-c 120 -m 70" | tee --append $GITHUB_ENV
       - name: Get java soaking test configuration
         # NOTE (enowell): Java's JVM is heavy and needs more memory than others.
         if: ${{ matrix.language == 'java' }}

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -85,12 +85,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Get default soaking test configuration
-        if: ${{ matrix.language != 'java' && matrix.architecture != 'arm64' }}
+        # CPU baseline was obtained empirically based on the max value observed for Go in a complete run of soak test
+        if: ${{ matrix.language != 'java' }}
         run: |
-          echo SOAKING_TEST_CONFIG="-c 90 -m 70" | tee --append $GITHUB_ENV
+          echo SOAKING_TEST_CONFIG="-c 100 -m 70" | tee --append $GITHUB_ENV
       - name: Get java soaking test configuration
         # NOTE (enowell): Java's JVM is heavy and needs more memory than others.
-        if: ${{ matrix.language == 'java' || matrix.architecture == 'arm64' }}
+        if: ${{ matrix.language == 'java' }}
         run: |
           echo SOAKING_TEST_CONFIG="-c 200 -m 90" | tee --append $GITHUB_ENV
       - uses: actions/setup-node@v3

--- a/adot/utils/soak/soak.py
+++ b/adot/utils/soak/soak.py
@@ -50,8 +50,12 @@ def enableLambdaInsight(function_name, architecture):
 
 
 def parse_args():
-    # default setting
-    _soaking_time, _emitter_interval, _cpu_threshold, _memory_threshold = 10000, 5, 60, 45
+    _soaking_time = 10000
+    _emitter_interval = 5
+    _cpu_threshold = 100 # total cpu time in ms. This value was obtained
+    # empirically using the Max value from the Golang soak test as baseline.
+    _memory_threshold = 45 # Memory usage in %
+
     argument_list = sys.argv[1:]
     short_options = "i:t:e:n:c:m:a:"
     long_options = [

--- a/adot/utils/soak/soak.py
+++ b/adot/utils/soak/soak.py
@@ -50,12 +50,8 @@ def enableLambdaInsight(function_name, architecture):
 
 
 def parse_args():
-    _soaking_time = 10000
-    _emitter_interval = 5
-    _cpu_threshold = 100 # total cpu time in ms. This value was obtained
-    # empirically using the Max value from the Golang soak test as baseline.
-    _memory_threshold = 45 # Memory usage in %
-
+    # default setting
+    _soaking_time, _emitter_interval, _cpu_threshold, _memory_threshold = 10000, 5, 60, 45
     argument_list = sys.argv[1:]
     short_options = "i:t:e:n:c:m:a:"
     long_options = [


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

**Description:** Update CPU threshold of soak tests. We are using the max values observed in Golang to set the threshold. Anything above this threshold should be considered an anomaly. It was observed that currently there is no difference between arm64 and amd64.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
