### PR TITLE
Use dotnet version 6 in main-build

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         if: ${{ matrix.language == 'dotnet' }}
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}


### PR DESCRIPTION
**Description:** 

The tests are updated in a way to test on dotnet-6 runtime.

Upstream PR : https://github.com/open-telemetry/opentelemetry-lambda/pull/434 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
