### PR TITLE
[chore] Use v0.22.0 for OTel-java Bom deps

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -24,8 +24,8 @@ spotless {
 }
 
 dependencies {
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.23.0"))
-    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.23.0-alpha"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom:1.22.0"))
+    compileOnly(platform("io.opentelemetry:opentelemetry-bom-alpha:1.22.0-alpha"))
     // Already included in wrapper so compileOnly
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-aws")


### PR DESCRIPTION
**Description:** 

This PR is created to use v0.22.0 bom Otel deps for java for Jan Release. 

- https://search.maven.org/artifact/io.opentelemetry/opentelemetry-bom/1.22.0/pom 
- https://search.maven.org/artifact/io.opentelemetry/opentelemetry-bom-alpha/1.22.0-alpha/pom

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
