### PR TITLE
Usage of go-version 1.19.6 in GH workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '^1.19.6'
       - uses: actions/setup-java@v3
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/main-build-python38.yml
+++ b/.github/workflows/main-build-python38.yml
@@ -33,7 +33,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '^1.19.6'
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -53,7 +53,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '^1.19.6'
       - uses: actions/setup-java@v3
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '^1.19.6'
       - uses: actions/setup-java@v3
         if: ${{ matrix.language == 'java' }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
         # above, always setup go 1.18.
         # if: ${{ env.TEST_LANGUAGE == 'go' }}
         with:
-          go-version: '^1.19.4'
+          go-version: '^1.19.6'
       - name: download layer tf file
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.19.4'
+          go-version: '^1.19.6'
       - uses: actions/setup-java@v3
         if: ${{ matrix.language == 'java' }}
         with:


### PR DESCRIPTION
**Description:**

This PR is created with an aim to use go-version:1.19.6 in all Github Workflows

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
