### PR TITLE
Use localhost for default collector OTLP receiver configuration

### DIFF
--- a/adot/collector/config.yaml
+++ b/adot/collector/config.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: "localhost:4317"
       http:
+        endpoint: "localhost:4318"
 
 exporters:
   logging:

--- a/adot/collector/config.yaml
+++ b/adot/collector/config.yaml
@@ -18,3 +18,6 @@ service:
     metrics:
       receivers: [otlp]
       exporters: [logging]
+  telemetry:
+    metrics:
+      address: localhost:8888


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
