### PR TITLE
Lock .NET versions to '6.0.405'

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         if: ${{ matrix.language == 'dotnet' }}
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.405'
       - name: Patch ADOT
         run: ./patch-upstream.sh
       - name: Build functions

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         if: ${{ matrix.language == 'dotnet' }}
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.405'
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         if: ${{ matrix.language == 'dotnet' }}
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.405'
       - name: Patch ADOT
         run: ./patch-upstream.sh
       - name: Build layers / sample functions

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/setup-dotnet@v3
         if: ${{ matrix.language == 'dotnet' }}
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.405'
       - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.INTEG_TEST_LAMBDA_ROLE_ARN }}


### PR DESCRIPTION
**Description:** 

The feb release of `.NET SDK` introduced breaking changes which failed our workflows when running `donet publish`. .NET maintainers have[ confirmed](https://github.com/dotnet/sdk/issues/30624#issuecomment-1432118204) that they will downgrade the error to a warning in the next release. Until then we should probably use the older SDK built until we investigate other workarounds.

**Link to tracking Issue:** https://github.com/dotnet/sdk/issues/30624#issuecomment-1432118204

Other ref: https://steven-giesel.com/blogPost/554ba273-9594-4d55-aac2-1366e28954b3

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.