### PR TITLE
Introduce Collector go.mod patch file

### DIFF
--- a/OTEL_Version.patch
+++ b/OTEL_Version.patch
@@ -1,0 +1,22 @@
+diff --git a/collector/go.mod b/collector/go.mod
+index f407749..10de919 100644
+--- a/collector/go.mod
++++ b/collector/go.mod
+@@ -16,12 +16,12 @@ replace cloud.google.com/go => cloud.google.com/go v0.107.0
+ 
+ require (
+ 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
+-	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.71.0
+-	github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents v0.71.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.70.0
++	github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents v0.70.0
+ 	github.com/stretchr/testify v1.8.1
+-	go.opentelemetry.io/collector v0.71.0
+-	go.opentelemetry.io/collector/component v0.71.0
+-	go.opentelemetry.io/collector/confmap v0.71.0
++	go.opentelemetry.io/collector v0.70.0
++	go.opentelemetry.io/collector/component v0.70.0
++	go.opentelemetry.io/collector/confmap v0.70.0
+ 	go.uber.org/multierr v1.9.0
+ 	go.uber.org/zap v1.24.0
+ )

--- a/OTEL_Version.patch
+++ b/OTEL_Version.patch
@@ -1,5 +1,5 @@
 diff --git a/collector/go.mod b/collector/go.mod
-index f407749..10de919 100644
+index f407749..bc6cb75 100644
 --- a/collector/go.mod
 +++ b/collector/go.mod
 @@ -16,12 +16,12 @@ replace cloud.google.com/go => cloud.google.com/go v0.107.0
@@ -20,3 +20,525 @@ index f407749..10de919 100644
  	go.uber.org/multierr v1.9.0
  	go.uber.org/zap v1.24.0
  )
+@@ -29,22 +29,22 @@ require (
+ require (
+ 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
+ 	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
+-	github.com/antonmedv/expr v1.12.0 // indirect
+-	github.com/aws/aws-sdk-go-v2 v1.17.4 // indirect
++	github.com/antonmedv/expr v1.10.3 // indirect
++	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
+ 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0 // indirect
+-	github.com/aws/aws-sdk-go-v2/config v1.18.12 // indirect
+-	github.com/aws/aws-sdk-go-v2/credentials v1.13.12 // indirect
+-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.22 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.28 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.22 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.29 // indirect
++	github.com/aws/aws-sdk-go-v2/config v1.18.8 // indirect
++	github.com/aws/aws-sdk-go-v2/credentials v1.13.8 // indirect
++	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.28 // indirect
+ 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.5.0 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.22 // indirect
++	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21 // indirect
+ 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.9.0 // indirect
+ 	github.com/aws/aws-sdk-go-v2/service/s3 v1.19.0 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/sso v1.12.1 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.1 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/sts v1.18.3 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sso v1.12.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sts v1.18.0 // indirect
+ 	github.com/aws/smithy-go v1.13.5 // indirect
+ 	github.com/benbjohnson/clock v1.3.0 // indirect
+ 	github.com/beorn7/perks v1.0.1 // indirect
+@@ -77,22 +77,22 @@ require (
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+ 	github.com/modern-go/reflect2 v1.0.2 // indirect
+ 	github.com/mostynb/go-grpc-compression v1.1.17 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.71.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.70.0 // indirect
+ 	github.com/pmezard/go-difflib v1.0.0 // indirect
+ 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+ 	github.com/prometheus/client_golang v1.14.0 // indirect
+@@ -102,7 +102,7 @@ require (
+ 	github.com/prometheus/prometheus v0.41.0 // indirect
+ 	github.com/prometheus/statsd_exporter v0.22.7 // indirect
+ 	github.com/rs/cors v1.8.3 // indirect
+-	github.com/shirou/gopsutil/v3 v3.23.1 // indirect
++	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
+ 	github.com/spf13/cobra v1.6.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+ 	github.com/tidwall/gjson v1.10.2 // indirect
+@@ -114,33 +114,33 @@ require (
+ 	github.com/tklauser/numcpus v0.6.0 // indirect
+ 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+ 	go.opencensus.io v0.24.0 // indirect
+-	go.opentelemetry.io/collector/consumer v0.71.0 // indirect
+-	go.opentelemetry.io/collector/exporter/loggingexporter v0.71.0 // indirect
+-	go.opentelemetry.io/collector/exporter/otlpexporter v0.71.0 // indirect
+-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.71.0 // indirect
+-	go.opentelemetry.io/collector/featuregate v0.71.0 // indirect
+-	go.opentelemetry.io/collector/pdata v1.0.0-rc5 // indirect
+-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.71.0 // indirect
+-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.71.0 // indirect
+-	go.opentelemetry.io/collector/semconv v0.71.0 // indirect
+-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.39.0 // indirect
+-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.39.0 // indirect
+-	go.opentelemetry.io/contrib/propagators/b3 v1.14.0 // indirect
+-	go.opentelemetry.io/otel v1.13.0 // indirect
+-	go.opentelemetry.io/otel/exporters/prometheus v0.36.0 // indirect
+-	go.opentelemetry.io/otel/metric v0.36.0 // indirect
+-	go.opentelemetry.io/otel/sdk v1.13.0 // indirect
+-	go.opentelemetry.io/otel/sdk/metric v0.36.0 // indirect
+-	go.opentelemetry.io/otel/trace v1.13.0 // indirect
++	go.opentelemetry.io/collector/consumer v0.70.0 // indirect
++	go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0 // indirect
++	go.opentelemetry.io/collector/exporter/otlpexporter v0.70.0 // indirect
++	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.70.0 // indirect
++	go.opentelemetry.io/collector/featuregate v0.70.0 // indirect
++	go.opentelemetry.io/collector/pdata v1.0.0-rc4 // indirect
++	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0 // indirect
++	go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0 // indirect
++	go.opentelemetry.io/collector/semconv v0.70.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
++	go.opentelemetry.io/contrib/propagators/b3 v1.12.0 // indirect
++	go.opentelemetry.io/otel v1.11.2 // indirect
++	go.opentelemetry.io/otel/exporters/prometheus v0.34.0 // indirect
++	go.opentelemetry.io/otel/metric v0.34.0 // indirect
++	go.opentelemetry.io/otel/sdk v1.11.2 // indirect
++	go.opentelemetry.io/otel/sdk/metric v0.34.0 // indirect
++	go.opentelemetry.io/otel/trace v1.11.2 // indirect
+ 	go.uber.org/atomic v1.10.0 // indirect
+ 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
+-	golang.org/x/net v0.7.0 // indirect
+-	golang.org/x/sys v0.5.0 // indirect
+-	golang.org/x/text v0.7.0 // indirect
++	golang.org/x/net v0.5.0 // indirect
++	golang.org/x/sys v0.4.0 // indirect
++	golang.org/x/text v0.6.0 // indirect
+ 	gonum.org/v1/gonum v0.12.0 // indirect
+ 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
+-	google.golang.org/grpc v1.52.3 // indirect
++	google.golang.org/grpc v1.52.0 // indirect
+ 	google.golang.org/protobuf v1.28.1 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+-)
++)
+\ No newline at end of file
+diff --git a/collector/lambdacomponents/go.mod b/collector/lambdacomponents/go.mod
+index dd60e60..df33eec 100644
+--- a/collector/lambdacomponents/go.mod
++++ b/collector/lambdacomponents/go.mod
+@@ -3,39 +3,39 @@ module github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents
+ go 1.18
+ 
+ require (
+-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.71.0
+-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.71.0
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.71.0
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.71.0
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.71.0
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.71.0
+-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.71.0
+-	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.71.0
+-	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.71.0
+-	go.opentelemetry.io/collector v0.71.0
+-	go.opentelemetry.io/collector/exporter/loggingexporter v0.71.0
+-	go.opentelemetry.io/collector/exporter/otlpexporter v0.71.0
+-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.71.0
+-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.71.0
+-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.71.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.70.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.70.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.70.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.70.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.70.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.70.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.70.0
++	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.70.0
++	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.70.0
++	go.opentelemetry.io/collector v0.70.0
++	go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0
++	go.opentelemetry.io/collector/exporter/otlpexporter v0.70.0
++	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.70.0
++	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0
++	go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0
+ 	go.uber.org/multierr v1.9.0
+ )
+ 
+ require (
+ 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
+ 	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
+-	github.com/antonmedv/expr v1.12.0 // indirect
+-	github.com/aws/aws-sdk-go-v2 v1.17.4 // indirect
+-	github.com/aws/aws-sdk-go-v2/config v1.18.12 // indirect
+-	github.com/aws/aws-sdk-go-v2/credentials v1.13.12 // indirect
+-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.22 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.28 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.22 // indirect
+-	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.29 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.22 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/sso v1.12.1 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.1 // indirect
+-	github.com/aws/aws-sdk-go-v2/service/sts v1.18.3 // indirect
++	github.com/antonmedv/expr v1.10.3 // indirect
++	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
++	github.com/aws/aws-sdk-go-v2/config v1.18.8 // indirect
++	github.com/aws/aws-sdk-go-v2/credentials v1.13.8 // indirect
++	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.28 // indirect
++	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sso v1.12.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sts v1.18.0 // indirect
+ 	github.com/aws/smithy-go v1.13.5 // indirect
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
+@@ -67,14 +67,14 @@ require (
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+ 	github.com/modern-go/reflect2 v1.0.2 // indirect
+ 	github.com/mostynb/go-grpc-compression v1.1.17 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.71.0 // indirect
+-	github.com/open-telemetry/opentelemetry-lambda/collector v0.71.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-lambda/collector v0.70.0 // indirect
+ 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+ 	github.com/prometheus/client_golang v1.14.0 // indirect
+ 	github.com/prometheus/client_model v0.3.0 // indirect
+@@ -83,7 +83,7 @@ require (
+ 	github.com/prometheus/prometheus v0.41.0 // indirect
+ 	github.com/prometheus/statsd_exporter v0.22.7 // indirect
+ 	github.com/rs/cors v1.8.3 // indirect
+-	github.com/shirou/gopsutil/v3 v3.23.1 // indirect
++	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
+ 	github.com/spf13/cobra v1.6.1 // indirect
+ 	github.com/spf13/pflag v1.0.5 // indirect
+ 	github.com/tidwall/gjson v1.10.2 // indirect
+@@ -95,30 +95,30 @@ require (
+ 	github.com/tklauser/numcpus v0.6.0 // indirect
+ 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+ 	go.opencensus.io v0.24.0 // indirect
+-	go.opentelemetry.io/collector/component v0.71.0 // indirect
+-	go.opentelemetry.io/collector/confmap v0.71.0 // indirect
+-	go.opentelemetry.io/collector/consumer v0.71.0 // indirect
+-	go.opentelemetry.io/collector/featuregate v0.71.0 // indirect
+-	go.opentelemetry.io/collector/pdata v1.0.0-rc5 // indirect
+-	go.opentelemetry.io/collector/semconv v0.71.0 // indirect
+-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.39.0 // indirect
+-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.39.0 // indirect
+-	go.opentelemetry.io/contrib/propagators/b3 v1.14.0 // indirect
+-	go.opentelemetry.io/otel v1.13.0 // indirect
+-	go.opentelemetry.io/otel/exporters/prometheus v0.36.0 // indirect
+-	go.opentelemetry.io/otel/metric v0.36.0 // indirect
+-	go.opentelemetry.io/otel/sdk v1.13.0 // indirect
+-	go.opentelemetry.io/otel/sdk/metric v0.36.0 // indirect
+-	go.opentelemetry.io/otel/trace v1.13.0 // indirect
++	go.opentelemetry.io/collector/component v0.70.0 // indirect
++	go.opentelemetry.io/collector/confmap v0.70.0 // indirect
++	go.opentelemetry.io/collector/consumer v0.70.0 // indirect
++	go.opentelemetry.io/collector/featuregate v0.70.0 // indirect
++	go.opentelemetry.io/collector/pdata v1.0.0-rc4 // indirect
++	go.opentelemetry.io/collector/semconv v0.70.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
++	go.opentelemetry.io/contrib/propagators/b3 v1.12.0 // indirect
++	go.opentelemetry.io/otel v1.11.2 // indirect
++	go.opentelemetry.io/otel/exporters/prometheus v0.34.0 // indirect
++	go.opentelemetry.io/otel/metric v0.34.0 // indirect
++	go.opentelemetry.io/otel/sdk v1.11.2 // indirect
++	go.opentelemetry.io/otel/sdk/metric v0.34.0 // indirect
++	go.opentelemetry.io/otel/trace v1.11.2 // indirect
+ 	go.uber.org/atomic v1.10.0 // indirect
+ 	go.uber.org/zap v1.24.0 // indirect
+ 	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
+-	golang.org/x/net v0.7.0 // indirect
+-	golang.org/x/sys v0.5.0 // indirect
+-	golang.org/x/text v0.7.0 // indirect
++	golang.org/x/net v0.5.0 // indirect
++	golang.org/x/sys v0.4.0 // indirect
++	golang.org/x/text v0.6.0 // indirect
+ 	gonum.org/v1/gonum v0.12.0 // indirect
+ 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
+-	google.golang.org/grpc v1.52.3 // indirect
++	google.golang.org/grpc v1.52.0 // indirect
+ 	google.golang.org/protobuf v1.28.1 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+@@ -134,4 +134,4 @@ replace github.com/open-telemetry/opentelemetry-lambda/collector => ../
+ 
+ replace github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor => ../processor/coldstartprocessor
+ 
+-replace github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver => ../receiver/telemetryapireceiver
++replace github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver => ../receiver/telemetryapireceiver
+\ No newline at end of file
+diff --git a/collector/processor/coldstartprocessor/go.mod b/collector/processor/coldstartprocessor/go.mod
+index 3b251e9..d3e38dd 100644
+--- a/collector/processor/coldstartprocessor/go.mod
++++ b/collector/processor/coldstartprocessor/go.mod
+@@ -5,11 +5,11 @@ go 1.19
+ require (
+ 	github.com/cespare/xxhash v1.1.0
+ 	github.com/stretchr/testify v1.8.1
+-	go.opentelemetry.io/collector v0.71.0
+-	go.opentelemetry.io/collector/component v0.71.0
+-	go.opentelemetry.io/collector/consumer v0.71.0
+-	go.opentelemetry.io/collector/pdata v1.0.0-rc5
+-	go.opentelemetry.io/collector/semconv v0.71.0
++	go.opentelemetry.io/collector v0.70.0
++	go.opentelemetry.io/collector/component v0.70.0
++	go.opentelemetry.io/collector/consumer v0.70.0
++	go.opentelemetry.io/collector/pdata v1.0.0-rc4
++	go.opentelemetry.io/collector/semconv v0.70.0
+ 	go.uber.org/multierr v1.9.0
+ 	go.uber.org/zap v1.24.0
+ )
+@@ -27,17 +27,17 @@ require (
+ 	github.com/modern-go/reflect2 v1.0.2 // indirect
+ 	github.com/pmezard/go-difflib v1.0.0 // indirect
+ 	go.opencensus.io v0.24.0 // indirect
+-	go.opentelemetry.io/collector/confmap v0.71.0 // indirect
+-	go.opentelemetry.io/collector/featuregate v0.71.0 // indirect
+-	go.opentelemetry.io/otel v1.13.0 // indirect
+-	go.opentelemetry.io/otel/metric v0.36.0 // indirect
+-	go.opentelemetry.io/otel/trace v1.13.0 // indirect
++	go.opentelemetry.io/collector/confmap v0.70.0 // indirect
++	go.opentelemetry.io/collector/featuregate v0.70.0 // indirect
++	go.opentelemetry.io/otel v1.11.2 // indirect
++	go.opentelemetry.io/otel/metric v0.34.0 // indirect
++	go.opentelemetry.io/otel/trace v1.11.2 // indirect
+ 	go.uber.org/atomic v1.10.0 // indirect
+-	golang.org/x/net v0.7.0 // indirect
+-	golang.org/x/sys v0.5.0 // indirect
+-	golang.org/x/text v0.7.0 // indirect
++	golang.org/x/net v0.5.0 // indirect
++	golang.org/x/sys v0.4.0 // indirect
++	golang.org/x/text v0.6.0 // indirect
+ 	google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 // indirect
+-	google.golang.org/grpc v1.52.3 // indirect
++	google.golang.org/grpc v1.52.0 // indirect
+ 	google.golang.org/protobuf v1.28.1 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+-)
++)
+\ No newline at end of file
+diff --git a/collector/receiver/telemetryapireceiver/go.mod b/collector/receiver/telemetryapireceiver/go.mod
+index 980c680..bc6cb75 100644
+--- a/collector/receiver/telemetryapireceiver/go.mod
++++ b/collector/receiver/telemetryapireceiver/go.mod
+@@ -1,45 +1,146 @@
+-module github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver
++module github.com/open-telemetry/opentelemetry-lambda/collector
+ 
+ go 1.18
+ 
+-replace github.com/open-telemetry/opentelemetry-lambda/collector => ../../
++replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents => ./lambdacomponents
++
++replace github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor => ./processor/coldstartprocessor
++
++replace github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver => ./receiver/telemetryapireceiver
++
++// fixes ambiguous import error: found package cloud.google.com/go/compute/metadata in multiple modules:
++//        cloud.google.com/go
++//        cloud.google.com/go/compute
++// Force cloud.google.com/go to be at least v0.107.0, so that the metadata is not present.
++replace cloud.google.com/go => cloud.google.com/go v0.107.0
+ 
+ require (
+ 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
+-	github.com/open-telemetry/opentelemetry-lambda/collector v0.71.0
++	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.70.0
++	github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents v0.70.0
+ 	github.com/stretchr/testify v1.8.1
+-	go.opentelemetry.io/collector v0.71.0
+-	go.opentelemetry.io/collector/component v0.71.0
+-	go.opentelemetry.io/collector/consumer v0.71.0
+-	go.opentelemetry.io/collector/pdata v1.0.0-rc5
+-	go.opentelemetry.io/collector/semconv v0.71.0
++	go.opentelemetry.io/collector v0.70.0
++	go.opentelemetry.io/collector/component v0.70.0
++	go.opentelemetry.io/collector/confmap v0.70.0
++	go.uber.org/multierr v1.9.0
+ 	go.uber.org/zap v1.24.0
+ )
+ 
+ require (
++	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
++	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
++	github.com/antonmedv/expr v1.10.3 // indirect
++	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
++	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0 // indirect
++	github.com/aws/aws-sdk-go-v2/config v1.18.8 // indirect
++	github.com/aws/aws-sdk-go-v2/credentials v1.13.8 // indirect
++	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
++	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.28 // indirect
++	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.5.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21 // indirect
++	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.9.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/s3 v1.19.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sso v1.12.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0 // indirect
++	github.com/aws/aws-sdk-go-v2/service/sts v1.18.0 // indirect
++	github.com/aws/smithy-go v1.13.5 // indirect
++	github.com/benbjohnson/clock v1.3.0 // indirect
++	github.com/beorn7/perks v1.0.1 // indirect
++	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
++	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+ 	github.com/davecgh/go-spew v1.1.1 // indirect
++	github.com/felixge/httpsnoop v1.0.3 // indirect
++	github.com/fsnotify/fsnotify v1.6.0 // indirect
++	github.com/go-kit/log v0.2.1 // indirect
++	github.com/go-logfmt/logfmt v0.5.1 // indirect
++	github.com/go-logr/logr v1.2.3 // indirect
++	github.com/go-logr/stdr v1.2.2 // indirect
++	github.com/go-ole/go-ole v1.2.6 // indirect
++	github.com/gobwas/glob v0.2.3 // indirect
+ 	github.com/gogo/protobuf v1.3.2 // indirect
++	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+ 	github.com/golang/protobuf v1.5.2 // indirect
++	github.com/golang/snappy v0.0.4 // indirect
++	github.com/google/uuid v1.3.0 // indirect
++	github.com/iancoleman/strcase v0.2.0 // indirect
++	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+ 	github.com/json-iterator/go v1.1.12 // indirect
++	github.com/klauspost/compress v1.15.15 // indirect
+ 	github.com/knadh/koanf v1.5.0 // indirect
++	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
++	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+ 	github.com/mitchellh/copystructure v1.2.0 // indirect
+ 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+ 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+ 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+ 	github.com/modern-go/reflect2 v1.0.2 // indirect
++	github.com/mostynb/go-grpc-compression v1.1.17 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.70.0 // indirect
++	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.70.0 // indirect
+ 	github.com/pmezard/go-difflib v1.0.0 // indirect
+-	go.opentelemetry.io/collector/confmap v0.71.0 // indirect
+-	go.opentelemetry.io/collector/featuregate v0.71.0 // indirect
+-	go.opentelemetry.io/otel v1.13.0 // indirect
+-	go.opentelemetry.io/otel/metric v0.36.0 // indirect
+-	go.opentelemetry.io/otel/trace v1.13.0 // indirect
++	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
++	github.com/prometheus/client_golang v1.14.0 // indirect
++	github.com/prometheus/client_model v0.3.0 // indirect
++	github.com/prometheus/common v0.39.0 // indirect
++	github.com/prometheus/procfs v0.8.0 // indirect
++	github.com/prometheus/prometheus v0.41.0 // indirect
++	github.com/prometheus/statsd_exporter v0.22.7 // indirect
++	github.com/rs/cors v1.8.3 // indirect
++	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
++	github.com/spf13/cobra v1.6.1 // indirect
++	github.com/spf13/pflag v1.0.5 // indirect
++	github.com/tidwall/gjson v1.10.2 // indirect
++	github.com/tidwall/match v1.1.1 // indirect
++	github.com/tidwall/pretty v1.2.0 // indirect
++	github.com/tidwall/tinylru v1.1.0 // indirect
++	github.com/tidwall/wal v1.1.7 // indirect
++	github.com/tklauser/go-sysconf v0.3.11 // indirect
++	github.com/tklauser/numcpus v0.6.0 // indirect
++	github.com/yusufpapurcu/wmi v1.2.2 // indirect
++	go.opencensus.io v0.24.0 // indirect
++	go.opentelemetry.io/collector/consumer v0.70.0 // indirect
++	go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0 // indirect
++	go.opentelemetry.io/collector/exporter/otlpexporter v0.70.0 // indirect
++	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.70.0 // indirect
++	go.opentelemetry.io/collector/featuregate v0.70.0 // indirect
++	go.opentelemetry.io/collector/pdata v1.0.0-rc4 // indirect
++	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0 // indirect
++	go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0 // indirect
++	go.opentelemetry.io/collector/semconv v0.70.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
++	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
++	go.opentelemetry.io/contrib/propagators/b3 v1.12.0 // indirect
++	go.opentelemetry.io/otel v1.11.2 // indirect
++	go.opentelemetry.io/otel/exporters/prometheus v0.34.0 // indirect
++	go.opentelemetry.io/otel/metric v0.34.0 // indirect
++	go.opentelemetry.io/otel/sdk v1.11.2 // indirect
++	go.opentelemetry.io/otel/sdk/metric v0.34.0 // indirect
++	go.opentelemetry.io/otel/trace v1.11.2 // indirect
+ 	go.uber.org/atomic v1.10.0 // indirect
+-	go.uber.org/multierr v1.9.0 // indirect
+-	golang.org/x/net v0.7.0 // indirect
+-	golang.org/x/sys v0.5.0 // indirect
+-	golang.org/x/text v0.7.0 // indirect
++	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
++	golang.org/x/net v0.5.0 // indirect
++	golang.org/x/sys v0.4.0 // indirect
++	golang.org/x/text v0.6.0 // indirect
++	gonum.org/v1/gonum v0.12.0 // indirect
+ 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
+-	google.golang.org/grpc v1.52.3 // indirect
++	google.golang.org/grpc v1.52.0 // indirect
+ 	google.golang.org/protobuf v1.28.1 // indirect
++	gopkg.in/yaml.v2 v2.4.0 // indirect
+ 	gopkg.in/yaml.v3 v3.0.1 // indirect
+-)
++)
+\ No newline at end of file

--- a/OTEL_Version.patch
+++ b/OTEL_Version.patch
@@ -1,5 +1,5 @@
 diff --git a/collector/go.mod b/collector/go.mod
-index f407749..bc6cb75 100644
+index f407749..5d8f8ca 100644
 --- a/collector/go.mod
 +++ b/collector/go.mod
 @@ -16,12 +16,12 @@ replace cloud.google.com/go => cloud.google.com/go v0.107.0
@@ -103,7 +103,7 @@ index f407749..bc6cb75 100644
  	github.com/spf13/cobra v1.6.1 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
  	github.com/tidwall/gjson v1.10.2 // indirect
-@@ -114,33 +114,33 @@ require (
+@@ -114,33 +114,35 @@ require (
  	github.com/tklauser/numcpus v0.6.0 // indirect
  	github.com/yusufpapurcu/wmi v1.2.2 // indirect
  	go.opencensus.io v0.24.0 // indirect
@@ -158,11 +158,12 @@ index f407749..bc6cb75 100644
  	google.golang.org/protobuf v1.28.1 // indirect
  	gopkg.in/yaml.v2 v2.4.0 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
--)
-+)
+ )
++
++replace golang.org/x/net => golang.org/x/net v0.7.0
 \ No newline at end of file
 diff --git a/collector/lambdacomponents/go.mod b/collector/lambdacomponents/go.mod
-index dd60e60..df33eec 100644
+index dd60e60..6612cca 100644
 --- a/collector/lambdacomponents/go.mod
 +++ b/collector/lambdacomponents/go.mod
 @@ -3,39 +3,39 @@ module github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents
@@ -314,15 +315,15 @@ index dd60e60..df33eec 100644
  	google.golang.org/protobuf v1.28.1 // indirect
  	gopkg.in/yaml.v2 v2.4.0 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
-@@ -134,4 +134,4 @@ replace github.com/open-telemetry/opentelemetry-lambda/collector => ../
- 
+@@ -135,3 +135,5 @@ replace github.com/open-telemetry/opentelemetry-lambda/collector => ../
  replace github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor => ../processor/coldstartprocessor
  
--replace github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver => ../receiver/telemetryapireceiver
-+replace github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver => ../receiver/telemetryapireceiver
+ replace github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver => ../receiver/telemetryapireceiver
++
++replace golang.org/x/net => golang.org/x/net v0.7.0
 \ No newline at end of file
 diff --git a/collector/processor/coldstartprocessor/go.mod b/collector/processor/coldstartprocessor/go.mod
-index 3b251e9..d3e38dd 100644
+index 3b251e9..d8f7014 100644
 --- a/collector/processor/coldstartprocessor/go.mod
 +++ b/collector/processor/coldstartprocessor/go.mod
 @@ -5,11 +5,11 @@ go 1.19
@@ -342,7 +343,7 @@ index 3b251e9..d3e38dd 100644
  	go.uber.org/multierr v1.9.0
  	go.uber.org/zap v1.24.0
  )
-@@ -27,17 +27,17 @@ require (
+@@ -27,17 +27,19 @@ require (
  	github.com/modern-go/reflect2 v1.0.2 // indirect
  	github.com/pmezard/go-difflib v1.0.0 // indirect
  	go.opencensus.io v0.24.0 // indirect
@@ -357,10 +358,9 @@ index 3b251e9..d3e38dd 100644
 +	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 +	go.opentelemetry.io/otel/trace v1.11.2 // indirect
  	go.uber.org/atomic v1.10.0 // indirect
--	golang.org/x/net v0.7.0 // indirect
+ 	golang.org/x/net v0.7.0 // indirect
 -	golang.org/x/sys v0.5.0 // indirect
 -	golang.org/x/text v0.7.0 // indirect
-+	golang.org/x/net v0.5.0 // indirect
 +	golang.org/x/sys v0.4.0 // indirect
 +	golang.org/x/text v0.6.0 // indirect
  	google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 // indirect
@@ -368,37 +368,20 @@ index 3b251e9..d3e38dd 100644
 +	google.golang.org/grpc v1.52.0 // indirect
  	google.golang.org/protobuf v1.28.1 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
--)
-+)
+ )
++
++replace golang.org/x/net => golang.org/x/net v0.7.0
 \ No newline at end of file
 diff --git a/collector/receiver/telemetryapireceiver/go.mod b/collector/receiver/telemetryapireceiver/go.mod
-index 980c680..bc6cb75 100644
+index 980c680..ab716dc 100644
 --- a/collector/receiver/telemetryapireceiver/go.mod
 +++ b/collector/receiver/telemetryapireceiver/go.mod
-@@ -1,45 +1,146 @@
--module github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver
-+module github.com/open-telemetry/opentelemetry-lambda/collector
- 
- go 1.18
- 
--replace github.com/open-telemetry/opentelemetry-lambda/collector => ../../
-+replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents => ./lambdacomponents
-+
-+replace github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor => ./processor/coldstartprocessor
-+
-+replace github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver => ./receiver/telemetryapireceiver
-+
-+// fixes ambiguous import error: found package cloud.google.com/go/compute/metadata in multiple modules:
-+//        cloud.google.com/go
-+//        cloud.google.com/go/compute
-+// Force cloud.google.com/go to be at least v0.107.0, so that the metadata is not present.
-+replace cloud.google.com/go => cloud.google.com/go v0.107.0
+@@ -6,13 +6,13 @@ replace github.com/open-telemetry/opentelemetry-lambda/collector => ../../
  
  require (
  	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
 -	github.com/open-telemetry/opentelemetry-lambda/collector v0.71.0
-+	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.70.0
-+	github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents v0.70.0
++	github.com/open-telemetry/opentelemetry-lambda/collector v0.70.0
  	github.com/stretchr/testify v1.8.1
 -	go.opentelemetry.io/collector v0.71.0
 -	go.opentelemetry.io/collector/component v0.71.0
@@ -407,138 +390,39 @@ index 980c680..bc6cb75 100644
 -	go.opentelemetry.io/collector/semconv v0.71.0
 +	go.opentelemetry.io/collector v0.70.0
 +	go.opentelemetry.io/collector/component v0.70.0
-+	go.opentelemetry.io/collector/confmap v0.70.0
-+	go.uber.org/multierr v1.9.0
++	go.opentelemetry.io/collector/consumer v0.70.0
++	go.opentelemetry.io/collector/pdata v1.0.0-rc4
++	go.opentelemetry.io/collector/semconv v0.70.0
  	go.uber.org/zap v1.24.0
  )
  
- require (
-+	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
-+	github.com/alecthomas/participle/v2 v2.0.0-beta.5 // indirect
-+	github.com/antonmedv/expr v1.10.3 // indirect
-+	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
-+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0 // indirect
-+	github.com/aws/aws-sdk-go-v2/config v1.18.8 // indirect
-+	github.com/aws/aws-sdk-go-v2/credentials v1.13.8 // indirect
-+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21 // indirect
-+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
-+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
-+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.28 // indirect
-+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.5.0 // indirect
-+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21 // indirect
-+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.9.0 // indirect
-+	github.com/aws/aws-sdk-go-v2/service/s3 v1.19.0 // indirect
-+	github.com/aws/aws-sdk-go-v2/service/sso v1.12.0 // indirect
-+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0 // indirect
-+	github.com/aws/aws-sdk-go-v2/service/sts v1.18.0 // indirect
-+	github.com/aws/smithy-go v1.13.5 // indirect
-+	github.com/benbjohnson/clock v1.3.0 // indirect
-+	github.com/beorn7/perks v1.0.1 // indirect
-+	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
-+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
- 	github.com/davecgh/go-spew v1.1.1 // indirect
-+	github.com/felixge/httpsnoop v1.0.3 // indirect
-+	github.com/fsnotify/fsnotify v1.6.0 // indirect
-+	github.com/go-kit/log v0.2.1 // indirect
-+	github.com/go-logfmt/logfmt v0.5.1 // indirect
-+	github.com/go-logr/logr v1.2.3 // indirect
-+	github.com/go-logr/stdr v1.2.2 // indirect
-+	github.com/go-ole/go-ole v1.2.6 // indirect
-+	github.com/gobwas/glob v0.2.3 // indirect
- 	github.com/gogo/protobuf v1.3.2 // indirect
-+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
- 	github.com/golang/protobuf v1.5.2 // indirect
-+	github.com/golang/snappy v0.0.4 // indirect
-+	github.com/google/uuid v1.3.0 // indirect
-+	github.com/iancoleman/strcase v0.2.0 // indirect
-+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
- 	github.com/json-iterator/go v1.1.12 // indirect
-+	github.com/klauspost/compress v1.15.15 // indirect
- 	github.com/knadh/koanf v1.5.0 // indirect
-+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
- 	github.com/mitchellh/copystructure v1.2.0 // indirect
- 	github.com/mitchellh/mapstructure v1.5.0 // indirect
- 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+@@ -28,18 +28,20 @@ require (
  	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
  	github.com/modern-go/reflect2 v1.0.2 // indirect
-+	github.com/mostynb/go-grpc-compression v1.1.17 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-lambda/collector/processor/coldstartprocessor v0.70.0 // indirect
-+	github.com/open-telemetry/opentelemetry-lambda/collector/receiver/telemetryapireceiver v0.70.0 // indirect
  	github.com/pmezard/go-difflib v1.0.0 // indirect
 -	go.opentelemetry.io/collector/confmap v0.71.0 // indirect
 -	go.opentelemetry.io/collector/featuregate v0.71.0 // indirect
 -	go.opentelemetry.io/otel v1.13.0 // indirect
 -	go.opentelemetry.io/otel/metric v0.36.0 // indirect
 -	go.opentelemetry.io/otel/trace v1.13.0 // indirect
-+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-+	github.com/prometheus/client_golang v1.14.0 // indirect
-+	github.com/prometheus/client_model v0.3.0 // indirect
-+	github.com/prometheus/common v0.39.0 // indirect
-+	github.com/prometheus/procfs v0.8.0 // indirect
-+	github.com/prometheus/prometheus v0.41.0 // indirect
-+	github.com/prometheus/statsd_exporter v0.22.7 // indirect
-+	github.com/rs/cors v1.8.3 // indirect
-+	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
-+	github.com/spf13/cobra v1.6.1 // indirect
-+	github.com/spf13/pflag v1.0.5 // indirect
-+	github.com/tidwall/gjson v1.10.2 // indirect
-+	github.com/tidwall/match v1.1.1 // indirect
-+	github.com/tidwall/pretty v1.2.0 // indirect
-+	github.com/tidwall/tinylru v1.1.0 // indirect
-+	github.com/tidwall/wal v1.1.7 // indirect
-+	github.com/tklauser/go-sysconf v0.3.11 // indirect
-+	github.com/tklauser/numcpus v0.6.0 // indirect
-+	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-+	go.opencensus.io v0.24.0 // indirect
-+	go.opentelemetry.io/collector/consumer v0.70.0 // indirect
-+	go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0 // indirect
-+	go.opentelemetry.io/collector/exporter/otlpexporter v0.70.0 // indirect
-+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.70.0 // indirect
++	go.opentelemetry.io/collector/confmap v0.70.0 // indirect
 +	go.opentelemetry.io/collector/featuregate v0.70.0 // indirect
-+	go.opentelemetry.io/collector/pdata v1.0.0-rc4 // indirect
-+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0 // indirect
-+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0 // indirect
-+	go.opentelemetry.io/collector/semconv v0.70.0 // indirect
-+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
-+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
-+	go.opentelemetry.io/contrib/propagators/b3 v1.12.0 // indirect
 +	go.opentelemetry.io/otel v1.11.2 // indirect
-+	go.opentelemetry.io/otel/exporters/prometheus v0.34.0 // indirect
 +	go.opentelemetry.io/otel/metric v0.34.0 // indirect
-+	go.opentelemetry.io/otel/sdk v1.11.2 // indirect
-+	go.opentelemetry.io/otel/sdk/metric v0.34.0 // indirect
 +	go.opentelemetry.io/otel/trace v1.11.2 // indirect
  	go.uber.org/atomic v1.10.0 // indirect
--	go.uber.org/multierr v1.9.0 // indirect
--	golang.org/x/net v0.7.0 // indirect
+ 	go.uber.org/multierr v1.9.0 // indirect
+ 	golang.org/x/net v0.7.0 // indirect
 -	golang.org/x/sys v0.5.0 // indirect
 -	golang.org/x/text v0.7.0 // indirect
-+	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 // indirect
-+	golang.org/x/net v0.5.0 // indirect
 +	golang.org/x/sys v0.4.0 // indirect
 +	golang.org/x/text v0.6.0 // indirect
-+	gonum.org/v1/gonum v0.12.0 // indirect
  	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 // indirect
 -	google.golang.org/grpc v1.52.3 // indirect
 +	google.golang.org/grpc v1.52.0 // indirect
  	google.golang.org/protobuf v1.28.1 // indirect
-+	gopkg.in/yaml.v2 v2.4.0 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
--)
-+)
+ )
++
++replace golang.org/x/net => golang.org/x/net v0.7.0
 \ No newline at end of file

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -24,6 +24,9 @@ patch -p2 < ../../collector.patch
 # patch manager.go to remove lambdacomponents attribute
 patch -p2 < ../../manager.patch
 
+# patch otel version on collector/go.mod
+patch -p2 < ../../OTEL_Version.patch
+
 # Replace OTel Collector with ADOT Collector
 go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.26.0
 

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -18,7 +18,7 @@ cp -rf adot/* opentelemetry-lambda/
 cd opentelemetry-lambda/collector
 
 # patch otel version on collector/go.mod
-patch < ../../OTEL_Version.patch
+patch -p2 < ../../OTEL_Version.patch
 
 # patch collector startup to remove HTTP and S3 confmap providers
 # and set ADOT-specific BuildInfo

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -17,15 +17,15 @@ cp -rf adot/* opentelemetry-lambda/
 # collector used in each Lambda layer
 cd opentelemetry-lambda/collector
 
+# patch otel version on collector/go.mod
+patch < ../../OTEL_Version.patch
+
 # patch collector startup to remove HTTP and S3 confmap providers
 # and set ADOT-specific BuildInfo
 patch -p2 < ../../collector.patch
 
 # patch manager.go to remove lambdacomponents attribute
 patch -p2 < ../../manager.patch
-
-# patch otel version on collector/go.mod
-patch -p2 < ../../OTEL_Version.patch
 
 # Replace OTel Collector with ADOT Collector
 go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=github.com/aws-observability/aws-otel-collector/pkg/lambdacomponents@v0.26.0


### PR DESCRIPTION
**Description:** 

Introduce Collector `go.mod` patch file. This is to maintain upstream collector parity between ADOT collector and lambda layers in the same release cycle.

Update upstream commit to update python dependency 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
