### PR TITLE
CGO_ENABLED=0

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -9,4 +9,4 @@ popd || exit
 # Build sample app
 
 cd ../opentelemetry-lambda/go/sample-apps/function || exit
-./build.sh
+CGO_ENABLED=0 ./build.sh


### PR DESCRIPTION
**Description:** 

Update `CGO_ENABLED=0`

This is to avoid the below error message while trying to invoke the `go sample app` using `provided.al2` runtime


`/var/task/bootstrap: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /var/task/bootstrap)`



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
