### PR TITLE
Add SQS handler script

### DIFF
--- a/java/build.sh
+++ b/java/build.sh
@@ -40,6 +40,7 @@ rm opentelemetry-java-wrapper.zip
 mv otel-handler otel-handler-upstream
 mv otel-stream-handler otel-stream-handler-upstream
 mv otel-proxy-handler otel-proxy-handler-upstream
+mv otel-sqs-handler otel-sqs-handler-upstream
 cp "$SOURCEDIR"/scripts/* .
 unzip -qo ../../../../collector/build/collector-extension.zip
 zip -qr opentelemetry-java-wrapper.zip *

--- a/java/scripts/otel-sqs-handler
+++ b/java/scripts/otel-sqs-handler
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES=true
+
+export OTEL_PROPAGATORS="${OTEL_PROPAGATORS:-xray,tracecontext,b3,b3multi}"
+
+source /opt/otel-sqs-handler-upstream


### PR DESCRIPTION
**Description:** 
This PR adds SQS handler script to adot layer

[This](https://aws-otel.github.io/docs/getting-started/lambda/lambda-java#enable-auto-instrumentation-for-your-lambda-function) mentions presence of /opt/otel-sqs-handler but script doesn't exist


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
