### PR TITLE
Add support to confmap providers: s3, http and https.

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -30,6 +30,7 @@ jobs:
         language: [ dotnet, go, java, nodejs, python ]
         sample-app: [ aws-sdk ]
         instrumentation-type: [ wrapper ]
+        confmap: [""]
         include:
           - language: java
             sample-app: aws-sdk
@@ -39,6 +40,36 @@ jobs:
             sample-app: aws-sdk
             instrumentation-type: agent
             architecture: arm64
+          - language: java
+            sample-app: aws-sdk
+            instrumentation-type: agent-confmap
+            architecture: amd64
+            confmap: s3
+          - language: java
+            sample-app: aws-sdk
+            instrumentation-type: agent-confmap
+            architecture: arm64
+            confmap: s3
+          - language: java
+            sample-app: aws-sdk
+            instrumentation-type: agent-confmap
+            architecture: amd64
+            confmap: http
+          - language: java
+            sample-app: aws-sdk
+            instrumentation-type: agent-confmap
+            architecture: arm64
+            confmap: http
+          - language: java
+            sample-app: aws-sdk
+            instrumentation-type: agent-confmap
+            architecture: amd64
+            confmap: https
+          - language: java
+            sample-app: aws-sdk
+            instrumentation-type: agent-confmap
+            architecture: arm64
+            confmap: https
           - language: java
             sample-app: okhttp
             instrumentation-type: wrapper
@@ -142,6 +173,7 @@ jobs:
           TF_VAR_sdk_layer_name: opentelemetry-${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{ github.run_id }}
           TF_VAR_function_name: ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}
           TF_VAR_architecture: ${{ env.LAMBDA_FUNCTION_ARCH }}
+          TF_VAR_configuration_source: ${{ matrix.confmap }}
       - name: Extract endpoint
         id: extract-endpoint
         run: terraform output -raw api-gateway-url
@@ -175,7 +207,7 @@ jobs:
           cd test-framework
           ./gradlew :validator:run --args="-c default-lambda-validation.yml --endpoint ${{ steps.extract-endpoint.outputs.stdout }} --region $AWS_REGION"
       - name: validate java agent metric sample
-        if: ${{ matrix.language == 'java' && matrix.sample-app == 'aws-sdk' && matrix.instrumentation-type == 'agent' }}
+        if: ${{ matrix.language == 'java' && matrix.sample-app == 'aws-sdk' && startsWith(matrix.instrumentation-type, 'agent') }}
         run: |
           cp adot/utils/expected-templates/${{ matrix.language }}-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-metric.json \
              test-framework/validator/src/main/resources/expected-data-template/ampExpectedMetric.mustache

--- a/collector.patch
+++ b/collector.patch
@@ -1,31 +1,32 @@
 diff --git a/collector/internal/collector/collector.go b/collector/internal/collector/collector.go
-index 7cdea69..6fbd781 100644
+index 7cdea69..553e649 100644
 --- a/collector/internal/collector/collector.go
 +++ b/collector/internal/collector/collector.go
-@@ -19,13 +19,11 @@
- 	"fmt"
- 	"os"
- 
--	"github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider"
- 	"go.opentelemetry.io/collector/component"
- 	"go.opentelemetry.io/collector/confmap"
- 	"go.opentelemetry.io/collector/confmap/converter/expandconverter"
+@@ -26,6 +26,7 @@ import (
  	"go.opentelemetry.io/collector/confmap/provider/envprovider"
  	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
--	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
+ 	"go.opentelemetry.io/collector/confmap/provider/httpprovider"
++	"go.opentelemetry.io/collector/confmap/provider/httpsprovider"
  	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
  	"go.opentelemetry.io/collector/otelcol"
  	"go.uber.org/zap"
-@@ -57,7 +55,7 @@
+@@ -57,7 +58,14 @@ func getConfig(logger *zap.Logger) string {
  
  func NewCollector(logger *zap.Logger, factories otelcol.Factories, version string) *Collector {
  	l := logger.Named("NewCollector")
 -	providers := []confmap.Provider{fileprovider.New(), envprovider.New(), yamlprovider.New(), httpprovider.New(), s3provider.New()}
-+	providers := []confmap.Provider{fileprovider.New(), envprovider.New(), yamlprovider.New()}
++	providers := []confmap.Provider{
++		fileprovider.New(),
++		envprovider.New(),
++		yamlprovider.New(),
++		httpprovider.New(),
++		s3provider.New(),
++		httpsprovider.New(),
++	}
  	mapProvider := make(map[string]confmap.Provider, len(providers))
  
  	for _, provider := range providers {
-@@ -89,8 +87,8 @@
+@@ -89,8 +97,8 @@ func NewCollector(logger *zap.Logger, factories otelcol.Factories, version strin
  func (c *Collector) Start(ctx context.Context) error {
  	params := otelcol.CollectorSettings{
  		BuildInfo: component.BuildInfo{

--- a/java/integration-tests/aws-sdk/agent-confmap/README.md
+++ b/java/integration-tests/aws-sdk/agent-confmap/README.md
@@ -1,0 +1,8 @@
+# Introduction
+
+This integration test will test confmap providers: s3, http and https.
+
+It works by storing the AMP workspace that is unique to the test case in the remote location
+, and after that this remote configuration is referenced in the main configuration using configuration expansion.
+
+The validation will only work if the remote endpoint is really accessible by the lambda layer.

--- a/java/integration-tests/aws-sdk/agent-confmap/main.tf
+++ b/java/integration-tests/aws-sdk/agent-confmap/main.tf
@@ -1,0 +1,103 @@
+data "aws_region" "current" {}
+
+module "test" {
+  source = "../../../../opentelemetry-lambda/java/integration-tests/aws-sdk/agent"
+
+  enable_collector_layer     = false
+  sdk_layer_name             = var.sdk_layer_name
+  function_name              = var.function_name
+  architecture               = var.architecture
+  collector_config_layer_arn = aws_lambda_layer_version.collector_config_layer.arn
+  tracing_mode               = "Active"
+}
+
+resource "aws_prometheus_workspace" "test_amp_workspace" {
+  alias = var.function_name
+  tags = {"ephemeral" = "true"}
+}
+
+locals {
+  // We have to scape '"" because the containing string will be interpreted as yaml
+  prw_content = <<EOT
+auth:
+  authenticator: sigv4auth
+endpoint: "${aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint}api/v1/remote_write"
+EOT
+}
+
+resource "random_id" "test_id" {
+
+  byte_length = 8
+}
+
+module "remote_configuration" {
+  source = "../../../../terraform/remote_configuration"
+
+  content = local.prw_content
+  scheme = var.configuration_source
+  testing_id = resource.random_id.test_id.hex
+}
+
+data "archive_file" "init" {
+  type       = "zip"
+  depends_on = [aws_prometheus_workspace.test_amp_workspace, data.aws_region.current]
+  source {
+    content  = <<EOT
+extensions:
+  sigv4auth:
+    region: ${data.aws_region.current.name}
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:4317"
+      http:
+        endpoint: "localhost:4318"
+exporters:
+  logging:
+  awsxray:
+  prometheusremotewrite: $${${module.remote_configuration.configuration_uri}}
+
+
+service:
+  extensions: [sigv4auth]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [awsxray]
+    metrics:
+      receivers: [otlp]
+      exporters: [logging, prometheusremotewrite]
+  telemetry:
+    metrics:
+      address: localhost:8888
+EOT
+    filename = "config.yaml"
+  }
+
+  output_path = "${path.module}/build/custom-config-layer.zip"
+}
+
+resource "aws_iam_role_policy_attachment" "test_xray" {
+  role       = module.test.function_role_name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "test_confmap" {
+  role       = module.test.function_role_name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "test_amp" {
+  role       = module.test.function_role_name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusFullAccess"
+}
+
+resource "aws_lambda_layer_version" "collector_config_layer" {
+  depends_on          = [data.archive_file.init]
+  layer_name          = "custom-config-layer"
+  filename            = "${path.module}/build/custom-config-layer.zip"
+  compatible_runtimes = ["java8", "java8.al2", "java11"]
+  license_info        = "Apache-2.0"
+}

--- a/java/integration-tests/aws-sdk/agent-confmap/outputs.tf
+++ b/java/integration-tests/aws-sdk/agent-confmap/outputs.tf
@@ -1,0 +1,11 @@
+output "api-gateway-url" {
+  value = module.test.api-gateway-url
+}
+
+output "sdk-layer-arn" {
+  value = module.test.sdk_layer_arn
+}
+
+output "amp_endpoint" {
+  value = aws_prometheus_workspace.test_amp_workspace.prometheus_endpoint
+}

--- a/java/integration-tests/aws-sdk/agent-confmap/variables.tf
+++ b/java/integration-tests/aws-sdk/agent-confmap/variables.tf
@@ -1,0 +1,35 @@
+variable "collector_layer_name" {
+  type        = string
+  description = "Name of published collector layer"
+  default     = "opentelemetry-collector"
+}
+
+variable "sdk_layer_name" {
+  type        = string
+  description = "Name of published SDK layer"
+  default     = "opentelemetry-java-agent"
+}
+
+variable "collector_config_layer_name" {
+  type        = string
+  description = "Name of published custom config layer"
+  default     = "custom-collector-config"
+}
+
+variable "function_name" {
+  type        = string
+  description = "Name of sample app function / API gateway"
+  default     = "lambda-java-awssdk-agent-amd64"
+}
+
+variable "architecture" {
+  type        = string
+  description = "Lambda function architecture, either arm64 or x86_64"
+  default     = "x86_64"
+}
+
+variable "configuration_source" {
+  type        = string
+  description = "source of the configuration"
+  default     = "https"
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,3 @@
+# Intro
+
+This directory contains modules that are reusable across testscases

--- a/terraform/remote_configuration/main.tf
+++ b/terraform/remote_configuration/main.tf
@@ -1,0 +1,46 @@
+// This module is used to generate remote uris based on the schema. This module is to test the s3, http and https
+// config map providers.
+
+data "aws_caller_identity" "caller" {}
+
+data "aws_region" "region" {}
+
+locals {
+  // Name of the bucket, according to the convention
+  // {prefix}-{region}-{account id}
+  // This bucket is created in the cdk_infra package.
+  bucket = "${var.configuration_bucket}-${data.aws_region.region.name}-${data.aws_caller_identity.caller.account_id}"
+}
+
+resource "aws_s3_object" "configuration_uri" {
+  bucket  = local.bucket
+  key     = var.testing_id
+  content = var.content
+}
+
+resource "null_resource" "presigned_url" {
+  depends_on = [
+    aws_s3_object.configuration_uri
+  ]
+  provisioner "local-exec" {
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html
+    // Create uri to access object using http or https.
+    command = "aws s3 presign s3://${local.bucket}/${var.testing_id} --expires-in 7200 > uri"
+  }
+}
+
+data "local_file" "uri" {
+  depends_on = [
+    null_resource.presigned_url
+  ]
+  filename = "./uri"
+}
+
+locals {
+  uri = {
+    s3    = "s3://${local.bucket}.s3.${data.aws_region.region.name}.amazonaws.com/${var.testing_id}"
+    https = trimspace(data.local_file.uri.content)
+    http  = replace(trimspace(data.local_file.uri.content), "/^https:/", "http:")
+  }
+  configuration_uri = local.uri[var.scheme]
+}

--- a/terraform/remote_configuration/outputs.tf
+++ b/terraform/remote_configuration/outputs.tf
@@ -1,0 +1,5 @@
+
+// URI of the remote configuration
+output "configuration_uri" {
+  value = local.configuration_uri
+}

--- a/terraform/remote_configuration/variables.tf
+++ b/terraform/remote_configuration/variables.tf
@@ -1,0 +1,24 @@
+// Bucket prefix
+variable "configuration_bucket" {
+  default = "adot-lambda-integ-test-configurations"
+}
+
+// Content of the configuration to be stored in s3
+variable "content" {
+  type = string
+}
+
+// The scheme that will be used in the url returned by this module
+variable "scheme" {
+  type = string
+
+  validation {
+    condition     = contains(["http", "https", "s3"], var.scheme)
+    error_message = "Invalid sheme for remote_configuration"
+  }
+}
+
+// Unique id, used to name the objects stored into s3
+variable "testing_id" {
+  type = string
+}


### PR DESCRIPTION
**Description:** 

* Add support to confmap providers: s3, http and https.
* Add integration tests based on the java agent integration tests.

**Testing:** Tested manually.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
