### PR TITLE
dependabot updates Mon Apr 30

### DIFF
--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -26,14 +26,14 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.4.1",
-    "@types/node": "18.15.11",
-    "@typescript-eslint/eslint-plugin": "5.57.1",
-    "@typescript-eslint/parser": "5.57.1",
-    "eslint": "8.38.0",
+    "@types/node": "18.16.3",
+    "@typescript-eslint/eslint-plugin": "5.59.1",
+    "@typescript-eslint/parser": "5.59.1",
+    "eslint": "8.39.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.27.5",
     "gts": "3.1.1",
-    "rimraf": "4.4.1",
+    "rimraf": "5.0.0",
     "typescript": "5.0.4"
   },
   "dependencies": {


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Bump @typescript-eslint/parser from 5.57.1 to 5.59.1 in /nodejs/wrapper-adot #551
Bump @types/node from 18.15.11 to 18.16.3 in /nodejs/wrapper-adot #550
Bump @typescript-eslint/eslint-plugin from 5.57.1 to 5.59.1 in /nodejs/wrapper-adot #549
Bump eslint from 8.38.0 to 8.39.0 in /nodejs/wrapper-adot #546
Bump rimraf from 4.4.1 to 5.0.0 in /nodejs/wrapper-adot #536

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
