### PR TITLE
Fix method for downloading Java Agent jar

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -19,8 +19,12 @@ java {
 
 spotless {
     java {
-        googleJavaFormat("1.9")
+        googleJavaFormat("1.15.0")
     }
+}
+
+val javaagentDependency by configurations.creating {
+    extendsFrom()
 }
 
 dependencies {
@@ -29,4 +33,14 @@ dependencies {
     // Already included in wrapper so compileOnly
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi")
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-aws")
+    javaagentDependency("software.amazon.opentelemetry:aws-opentelemetry-agent:1.26.0")
+}
+
+tasks.register<Copy>("download") {
+    from(javaagentDependency)
+    into("$buildDir/javaagent")
+}
+
+tasks.named("build") {
+    dependsOn("download")
 }

--- a/java/build.sh
+++ b/java/build.sh
@@ -19,9 +19,7 @@ cp ./build/libs/aws-otel-lambda-java-extensions.jar ../opentelemetry-lambda/java
 # Go to OTel Lambda Java folder
 cd ../opentelemetry-lambda/java || exit
 
-# Build the OTel Lambda Java folder which has ADOT Lambda Java configured code
-OTEL_VERSION=1.24.0
-./gradlew build -Potel.lambda.javaagent.dependency=software.amazon.opentelemetry:aws-opentelemetry-agent:$OTEL_VERSION
+./gradlew build
 
 # Combine Java Agent build and ADOT Collector
 pushd ./layer-javaagent/build/distributions || exit
@@ -29,6 +27,8 @@ unzip -qo opentelemetry-javaagent-layer.zip
 rm opentelemetry-javaagent-layer.zip
 mv otel-handler otel-handler-upstream
 cp "$SOURCEDIR"/scripts/otel-handler .
+# Copy ADOT Java Agent downloaded using Gradle task
+cp "$SOURCEDIR"/build/javaagent/aws-opentelemetry-agent*.jar ./opentelemetry-javaagent.jar
 unzip -qo ../../../../collector/build/collector-extension-$1.zip
 zip -qr opentelemetry-javaagent-layer.zip *
 popd || exit


### PR DESCRIPTION
**Description:**  Fix method for downloading java agent jar: Instead of relying on a flag that existed upstream and that was removed in this change https://github.com/open-telemetry/opentelemetry-lambda/pull/601, we are now downloading the ADOT Java agent ourselves and inserting it when the zip of the layer is created.

**Testing:** verified the content of the zip that was built.



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
