### PR TITLE
[chore] Update Opentelemetry-lambda sub module

### DIFF
--- a/collector.patch
+++ b/collector.patch
@@ -37,16 +37,3 @@ index 7cdea69..553e649 100644
  			Version:     c.version,
  		},
  		ConfigProvider: c.configProvider,
-diff --git a/collector/Makefile b/collector/Makefile
-index 8a3d532..e272d83 100644
---- a/collector/Makefile
-+++ b/collector/Makefile
-@@ -44,7 +44,7 @@ package: build
- 	@echo Package zip file for collector extension layer
- 	mkdir -p $(BUILD_SPACE)/collector-config
- 	cp config* $(BUILD_SPACE)/collector-config
--	cd $(BUILD_SPACE) && zip -r opentelemetry-collector-layer-$(GOARCH).zip collector-config extensions
-+	cd $(BUILD_SPACE) && zip -r collector-extension-$(GOARCH).zip collector-config extensions
- 
- .PHONY: publish
- publish:

--- a/dotnet/integration-tests/aws-sdk/wrapper/main.tf
+++ b/dotnet/integration-tests/aws-sdk/wrapper/main.tf
@@ -5,10 +5,10 @@ locals {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["dotnet6", "dotnetcore3.1"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "hello-lambda-function" {

--- a/go/integration-tests/aws-sdk/wrapper/main.tf
+++ b/go/integration-tests/aws-sdk/wrapper/main.tf
@@ -5,10 +5,10 @@ locals {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["provided.al2"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "hello-lambda-function" {

--- a/java/build.sh
+++ b/java/build.sh
@@ -57,7 +57,7 @@ mv otel-handler otel-handler-upstream
 cp "$SOURCEDIR"/scripts/otel-handler .
 # Copy ADOT Java Agent downloaded using Gradle task
 cp "$SOURCEDIR"/build/javaagent/aws-opentelemetry-agent*.jar ./opentelemetry-javaagent.jar
-unzip -qo ../../../../collector/build/collector-extension-$1.zip
+unzip -qo ../../../../collector/build/opentelemetry-collector-layer-$1.zip
 zip -qr opentelemetry-javaagent-layer.zip *
 popd || exit
 
@@ -69,6 +69,6 @@ mv otel-handler otel-handler-upstream
 mv otel-stream-handler otel-stream-handler-upstream
 mv otel-proxy-handler otel-proxy-handler-upstream
 cp "$SOURCEDIR"/scripts/* .
-unzip -qo ${SOURCEDIR}/../opentelemetry-lambda/collector/build/collector-extension-$1.zip
+unzip -qo ${SOURCEDIR}/../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-$1.zip
 zip -qr opentelemetry-java-wrapper.zip *
 popd || exit

--- a/java/integration-tests/aws-sdk/agent-confmap/main.tf
+++ b/java/integration-tests/aws-sdk/agent-confmap/main.tf
@@ -15,10 +15,10 @@ resource "aws_lambda_layer_version" "sdk_layer" {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "hello-lambda-function" {

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -13,10 +13,10 @@ resource "aws_lambda_layer_version" "sdk_layer" {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "hello-lambda-function" {

--- a/java/integration-tests/aws-sdk/wrapper/main.tf
+++ b/java/integration-tests/aws-sdk/wrapper/main.tf
@@ -13,10 +13,10 @@ resource "aws_lambda_layer_version" "sdk_layer" {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "hello-lambda-function" {

--- a/java/integration-tests/okhttp/wrapper/main.tf
+++ b/java/integration-tests/okhttp/wrapper/main.tf
@@ -13,10 +13,10 @@ resource "aws_lambda_layer_version" "sdk_layer" {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "hello-lambda-function" {

--- a/nodejs/build.sh
+++ b/nodejs/build.sh
@@ -29,5 +29,5 @@ cp "$SOURCEDIR"/wrapper-adot/build/src/adot-extension.* ./packages/layer/build/w
 
 cd ./packages/layer/build/workspace || exit
 rm ../layer.zip
-unzip -qo ../../../../../collector/build/collector-extension-$1.zip
+unzip -qo ../../../../../collector/build/opentelemetry-collector-layer-$1.zip
 zip -qr ../layer.zip *

--- a/nodejs/integration-tests/aws-sdk/wrapper/main.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/main.tf
@@ -13,10 +13,10 @@ resource "aws_lambda_layer_version" "sdk_layer" {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "hello-lambda-function" {

--- a/python/build.sh
+++ b/python/build.sh
@@ -24,8 +24,8 @@ cd ./build || exit
 pip install opentelemetry-sdk-extension-aws -t python/
 
 # Combine the layers
-unzip -qo layer.zip
-rm layer.zip
+unzip -qo opentelemetry-python-layer.zip
+rm opentelemetry-python-layer.zip
 unzip -qo ../../../collector/build/opentelemetry-collector-layer-$1.zip
 
 # Use our AWS scripts instead which extend and call OTel Lambda scripts

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -13,10 +13,10 @@ resource "aws_lambda_layer_version" "sdk_layer" {
 resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
-  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip"
+  filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
   compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
   license_info        = "Apache-2.0"
-  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/collector-extension-${local.architecture}.zip")
+  source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
 module "test-function" {


### PR DESCRIPTION
**Description:** 

This PR updates the `opentelemetry-lambda` submodule and fixes the naming convention of the collector extension layer used for the Python Lambda layer.

Tested Locally: 

![image](https://github.com/aws-observability/aws-otel-lambda/assets/41936996/91ff7847-9ee1-4215-9bd1-537655770acd)


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
