### PR TITLE
Python 3.10 runtime support for python lambda layer

### DIFF
--- a/.github/workflows/main-build-python39.yml
+++ b/.github/workflows/main-build-python39.yml
@@ -85,7 +85,7 @@ jobs:
           TF_VAR_sdk_layer_name: opentelemetry-python-aws-sdk-wrapper-${{ matrix.architecture }}
           TF_VAR_function_name: ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}
           TF_VAR_architecture: ${{ env.LAMBDA_FUNCTION_ARCH }}
-          TF_VAR_runtime: 'python3.8'
+          TF_VAR_runtime: 'python3.9'
       - name: Extract endpoint
         id: extract-endpoint
         run: terraform output -raw api-gateway-url

--- a/adot/python/src/template.yml
+++ b/adot/python/src/template.yml
@@ -14,7 +14,7 @@ Resources:
       Description: Opentelemetry Python layer
       ContentUri: ./otel
       CompatibleRuntimes:
-        - python3.8
+        - python3.10
         - python3.9
     Metadata:
       BuildMethod: makefile

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -5,7 +5,7 @@ locals {
 resource "aws_lambda_layer_version" "sdk_layer" {
   layer_name          = var.sdk_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/python/src/build/layer.zip"
-  compatible_runtimes = ["python3.8", "python3.9"]
+  compatible_runtimes = ["python3.10", "python3.9"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/python/src/build/layer.zip")
 }

--- a/python/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/python/integration-tests/aws-sdk/wrapper/variables.tf
@@ -25,7 +25,7 @@ variable "architecture" {
 variable "runtime" {
   type        = string
   description = "Python runtime version used for sample Lambda Function"
-  default     = "python3.9"
+  default     = "python3.10"
 }
 
 variable "tracing_mode" {


### PR DESCRIPTION
**Description:**
Add Support for python3.10 runtime lambda function and changes in integ test workflow to test against `python3.10` runtime
Updates `opentelemetry-lambda` submodule.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
