### PR TITLE
Test Python 3.11 runtime in integration tests

### DIFF
--- a/.github/workflows/main-build-python311.yml
+++ b/.github/workflows/main-build-python311.yml
@@ -1,5 +1,5 @@
-name: Python38 Layer Integration Test
-# This workflow is for verifying python3.9 layer in Lambda python3.8 environment
+name: Python-3.11 Layer Integration Test
+# This workflow is for verifying python3.11 layer in Lambda python3.8 environment
 on:
   push:
     branches: 
@@ -7,12 +7,12 @@ on:
       - release/*
     paths-ignore:
       - '.github/**'
-      - '!.github/workflows/main-build-python39.yml'
+      - '!.github/workflows/main-build-python311.yml'
       - '**.md'
   workflow_dispatch:
 
 concurrency:
-  group: main-build-python39-${{ github.ref_name }}
+  group: main-build-python311-${{ github.ref_name }}
   cancel-in-progress: true
 
 
@@ -22,7 +22,7 @@ permissions:
 jobs:
   integration-test:
     runs-on: ubuntu-20.04
-    name: Python39-${{ matrix.architecture }}-IntegrationTest
+    name: Python311-${{ matrix.architecture }}-IntegrationTest
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
           TF_VAR_sdk_layer_name: opentelemetry-python-aws-sdk-wrapper-${{ matrix.architecture }}
           TF_VAR_function_name: ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}
           TF_VAR_architecture: ${{ env.LAMBDA_FUNCTION_ARCH }}
-          TF_VAR_runtime: 'python3.9'
+          TF_VAR_runtime: 'python3.11'
       - name: Extract endpoint
         id: extract-endpoint
         run: terraform output -raw api-gateway-url

--- a/adot/python/src/template.yml
+++ b/adot/python/src/template.yml
@@ -14,8 +14,10 @@ Resources:
       Description: Opentelemetry Python layer
       ContentUri: ./otel
       CompatibleRuntimes:
-        - python3.10
+        - python3.8
         - python3.9
+        - python3.10
+        - python3.11
     Metadata:
       BuildMethod: makefile
   api:
@@ -28,7 +30,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: lambda_function.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.10
       CodeUri: ./function
       Description: Build ADOT Python Lambda layer and sample app from scratch
       MemorySize: 512

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -5,7 +5,7 @@ locals {
 resource "aws_lambda_layer_version" "sdk_layer" {
   layer_name          = var.sdk_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/python/src/build/layer.zip"
-  compatible_runtimes = ["python3.10", "python3.9"]
+  compatible_runtimes = ["python3.10", "python3.11"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/python/src/build/layer.zip")
 }

--- a/python/sample-apps/aws-sdk/deploy/wrapper/variables.tf
+++ b/python/sample-apps/aws-sdk/deploy/wrapper/variables.tf
@@ -13,5 +13,5 @@ variable "architecture" {
 variable "runtime" {
   type        = string
   description = "Python runtime version used for sample Lambda Function"
-  default     = "python3.9"
+  default     = "python3.10"
 }


### PR DESCRIPTION
**Description:** Test python lambda layer with Python 3.11 runtime in integration tests

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
