### PR TITLE
Run Integ tests for python 3.8 and 3.9 runtimes

### DIFF
--- a/.github/workflows/main-build-python.yml
+++ b/.github/workflows/main-build-python.yml
@@ -1,4 +1,4 @@
-name: Python-3.[8,9,10] Layer Integration Test
+name: Lambda Layer python3.[8,9,10] runtime Integration Test
 # This workflow is for verifying ADOT Python Lambda layer in Lambda Python3.[8,9,10] runtimes environment
 on:
   push:
@@ -7,7 +7,7 @@ on:
       - release/*
     paths-ignore:
       - '.github/**'
-      - '!.github/workflows/main-build-python311.yml'
+      - '!.github/workflows/main-build-python.yml'
       - '**.md'
   workflow_dispatch:
 

--- a/.github/workflows/main-build-python311.yml
+++ b/.github/workflows/main-build-python311.yml
@@ -1,5 +1,5 @@
-name: Python-3.11 Layer Integration Test
-# This workflow is for verifying python3.11 layer in Lambda python3.8 environment
+name: Python-3.[8,9,10] Layer Integration Test
+# This workflow is for verifying ADOT Python Lambda layer in Lambda Python3.[8,9,10] runtimes environment
 on:
   push:
     branches: 
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: main-build-python311-${{ github.ref_name }}
+  group: main-build-python3.[8,9,10]-${{ github.ref_name }}
   cancel-in-progress: true
 
 
@@ -22,11 +22,12 @@ permissions:
 jobs:
   integration-test:
     runs-on: ubuntu-20.04
-    name: Python311-${{ matrix.architecture }}-IntegrationTest
+    name: Python3.[8,9,10]-${{ matrix.architecture }}-IntegrationTest
     strategy:
       fail-fast: false
       matrix:
         architecture: [ amd64, arm64 ]
+        runtime: ["python3.8", "python3.9", "python3.10"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -86,7 +87,7 @@ jobs:
           TF_VAR_sdk_layer_name: opentelemetry-python-aws-sdk-wrapper-${{ matrix.architecture }}
           TF_VAR_function_name: ${{ env.TERRAFORM_LAMBDA_FUNCTION_NAME }}
           TF_VAR_architecture: ${{ env.LAMBDA_FUNCTION_ARCH }}
-          TF_VAR_runtime: 'python3.11'
+          TF_VAR_runtime: ${{ matrix.runtime }}
       - name: Extract endpoint
         id: extract-endpoint
         run: terraform output -raw api-gateway-url

--- a/.github/workflows/main-build-python311.yml
+++ b/.github/workflows/main-build-python311.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   integration-test:
     runs-on: ubuntu-20.04
-    name: Python3.[8,9,10]-${{ matrix.architecture }}-IntegrationTest
+    name: ${{ matrix.runtime }}-${{ matrix.architecture }}-IntegrationTest
     strategy:
       fail-fast: false
       matrix:

--- a/python/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/python/integration-tests/aws-sdk/wrapper/variables.tf
@@ -25,7 +25,7 @@ variable "architecture" {
 variable "runtime" {
   type        = string
   description = "Python runtime version used for sample Lambda Function"
-  default     = "python3.10"
+  default     = "python3.11"
 }
 
 variable "tracing_mode" {


### PR DESCRIPTION
**Description:** 
Run Integ tests for python 3.8 and 3.9 runtimes

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
