### PR TITLE
Patch java versions to v1.32.0

### DIFF
--- a/OTEL_Java_Version.patch
+++ b/OTEL_Java_Version.patch
@@ -1,0 +1,25 @@
+diff --git a/java/dependencyManagement/build.gradle.kts b/java/dependencyManagement/build.gradle.kts
+index 4d7087a..62dcbb7 100644
+--- a/java/dependencyManagement/build.gradle.kts
++++ b/java/dependencyManagement/build.gradle.kts
+@@ -9,16 +9,16 @@ plugins {
+ data class DependencySet(val group: String, val version: String, val modules: List<String>)
+ 
+ val DEPENDENCY_BOMS = listOf(
+-    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.0.0-alpha",
+-    "org.apache.logging.log4j:log4j-bom:2.22.1",
+-    "software.amazon.awssdk:bom:2.23.7"
++    "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.32.0-alpha",
++    "org.apache.logging.log4j:log4j-bom:2.22.0",
++    "software.amazon.awssdk:bom:2.21.42"
+ )
+ 
+ val DEPENDENCIES = listOf(
+     "com.amazonaws:aws-lambda-java-core:1.2.3",
+     "com.amazonaws:aws-lambda-java-events:3.11.4",
+     "com.squareup.okhttp3:okhttp:4.12.0",
+-    "io.opentelemetry.javaagent:opentelemetry-javaagent:2.0.0"
++    "io.opentelemetry.javaagent:opentelemetry-javaagent:1.32.0"
+ )
+ 
+ javaPlatform {

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -19,6 +19,15 @@ cp -rf adot/* opentelemetry-lambda/
 # Get current repo path
 CURRENT_DIR=$PWD
 
+cd opentelemetry-lambda/java
+# patch otel version on collector/go.mod
+PATCH_JAVA_VERSION="../../OTEL_Java_Version.patch"
+
+if [ -f $PATCH_JAVA_VERSION ]; then
+    patch -p2 < $PATCH_JAVA_VERSION;
+fi
+    cd ../..
+
 # Move to the upstream OTel Lambda Collector folder where we will build a
 # collector used in each Lambda layer
 cd opentelemetry-lambda/collector
@@ -29,6 +38,8 @@ PATCH_OTEL_VERSION="../../OTEL_Version.patch"
 if [ -f $PATCH_OTEL_VERSION ]; then
     patch -p2 < $PATCH_OTEL_VERSION;
 fi
+
+
 
 # patch collector startup to remove HTTP and S3 confmap providers
 # and set ADOT-specific BuildInfo


### PR DESCRIPTION
**Description:** Upstream is currently on java dependency v2.0.0 and we do not want that yet as it brings in breaking changes. Adding patch files to bring dependency back to 1.32.0

Testing: `./patch-upstream.sh`.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
