### PR TITLE
remove metrics

### DIFF
--- a/adot/collector/config.yaml
+++ b/adot/collector/config.yaml
@@ -15,9 +15,6 @@ service:
     traces:
       receivers: [otlp]
       exporters: [awsxray]
-    metrics:
-      receivers: [otlp]
-      exporters: [logging]
   telemetry:
     metrics:
       address: localhost:8888


### PR DESCRIPTION
**Description:** 

Remove metrics from sample config.yaml

Running `aws-otel-collector-arm64-ver-0-90-1:1` with the current config.yaml produces the following log on startup:

```
{
    "level": "info",
    "ts": 1709939437.9498036,
    "caller": "exporter@v0.90.1/exporter.go:275",
    "msg": "Deprecated component. Will be removed in future releases.",
    "kind": "exporter",
    "data_type": "metrics",
    "name": "logging"
}
```

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
