### PR TITLE
Remove java8.al2 runtime in java agent tests

### DIFF
--- a/.github/workflows/main-build-java.yml
+++ b/.github/workflows/main-build-java.yml
@@ -40,11 +40,6 @@ jobs:
             runtime: java11
           - sample-app: aws-sdk
             instrumentation-type: agent
-            architecture: amd64
-            confmap: noop
-            runtime: java8.al2
-          - sample-app: aws-sdk
-            instrumentation-type: agent
             architecture: arm64
             confmap: noop
             runtime: java17
@@ -53,11 +48,6 @@ jobs:
             architecture: arm64
             confmap: noop
             runtime: java11
-          - sample-app: aws-sdk
-            instrumentation-type: agent
-            architecture: arm64
-            confmap: noop
-            runtime: java8.al2
           - sample-app: aws-sdk
             instrumentation-type: agent-confmap
             architecture: amd64


### PR DESCRIPTION
**Description:** 

Follow up to https://github.com/aws-observability/aws-otel-lambda/pull/913 to remove java8.al2 tests in agent

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
