### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           echo LAYER_KIND=$(echo "${{ github.event.inputs.layer_name_keyword }}" | cut -d - -f 3) | tee --append $GITHUB_ENV
       - name: download layerARNs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}
@@ -275,7 +275,7 @@ jobs:
           go-version: '~1.21.10'
           check-latest: true
       - name: download layer tf file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: layer_${{ matrix.architecture }}.tf
       - name: Get terraform directory


### PR DESCRIPTION
Reverts aws-observability/aws-otel-lambda#809 to match upload artefacts and download artefacts match the versions for the compatibility - https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible