### PR TITLE
Add overwrite to upload-artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
+          overwrite: true
       - name: clean s3
         if: always()
         run: |
@@ -174,6 +175,7 @@ jobs:
         with:
           name: layer_${{ matrix.architecture }}.tf
           path: layer.tf
+          overwrite: true
   smoke-test:
     name: Smoke Test - (${{ matrix.aws_region }} - ${{ github.event.inputs.layer_name_keyword }} - ${{ matrix.architecture }})
     needs: generate-note


### PR DESCRIPTION
**Description:** In upload-artifact v4 github action, artifacts are immutable which means the same name for artifacts leads to an error.  Setting` overwrite: true` will retain the behavior we had with v3 and delete artifacts before uploading a new one.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
