### PR TITLE
Revert upload and download artifact to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,10 @@ jobs:
             --action lambda:GetLayerVersion
       - name: upload layer arn artifact
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
-          overwrite: true
       - name: clean s3
         if: always()
         run: |
@@ -127,7 +126,7 @@ jobs:
         run: |
           echo LAYER_KIND=$(echo "${{ github.event.inputs.layer_name_keyword }}" | cut -d - -f 3) | tee --append $GITHUB_ENV
       - name: download layerARNs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: ${{ env.LAYER_NAME }}
           path: ${{ env.LAYER_NAME }}
@@ -171,11 +170,10 @@ jobs:
           terraform fmt layer.tf
           cat layer.tf
       - name: upload layer tf file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: layer_${{ matrix.architecture }}.tf
           path: layer.tf
-          overwrite: true
   smoke-test:
     name: Smoke Test - (${{ matrix.aws_region }} - ${{ github.event.inputs.layer_name_keyword }} - ${{ matrix.architecture }})
     needs: generate-note
@@ -277,7 +275,7 @@ jobs:
           go-version: '~1.21.10'
           check-latest: true
       - name: download layer tf file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: layer_${{ matrix.architecture }}.tf
       - name: Get terraform directory


### PR DESCRIPTION
**Description:** There are some complications with upgrading upload-artifact and download-artifact to v4.  We will look to revert back to v3 for the time being until we can resolve these issues and upgrade if needed.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
