### PR TITLE
Update config.yaml

### DIFF
--- a/adot/collector/config.yaml
+++ b/adot/collector/config.yaml
@@ -9,6 +9,7 @@ receivers:
 exporters:
   logging:
   awsxray:
+  awsemf:
 
 service:
   pipelines:
@@ -17,7 +18,7 @@ service:
       exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [logging, awsemf]
   telemetry:
     metrics:
       address: localhost:8888

--- a/adot/collector/config.yaml
+++ b/adot/collector/config.yaml
@@ -7,7 +7,6 @@ receivers:
         endpoint: "localhost:4318"
 
 exporters:
-  logging:
   awsxray:
   awsemf:
 
@@ -18,7 +17,7 @@ service:
       exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging, awsemf]
+      exporters: [awsemf]
   telemetry:
     metrics:
       address: localhost:8888


### PR DESCRIPTION
Metrics will be exported by default to CloudWatch using the awsemf exporter.

**Description:** 
Metrics created in the Lambda function by the otel SDK are now exported to CloudWatch using the awsemf exporter.

**Link to tracking Issue:** 
https://github.com/aws-observability/aws-otel-lambda/issues/976

**Testing:** 
I deployed the updated config file with my application code to Lambda and used the env var to point to the updated config. Then created a metric in my function. I verified that the metric was created in CloudWatch.

**Documentation:** 
If this new default is agreed to, then documentation will need to be updated. Which I'm happy to do if this is approved on theory.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
