### PR TITLE
Use ubuntu-22.04 as GHA runner image

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   canary-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Canary Test - (${{ matrix.aws_region }} - ${{ matrix.language }} - ${{ matrix.sample-app }} - ${{ matrix.instrumentation-type }} - ${{ matrix.architecture }})
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-build-lambda-soak.yml
+++ b/.github/workflows/docker-build-lambda-soak.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build-lambda-soak:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS Credentials

--- a/.github/workflows/main-build-java.yml
+++ b/.github/workflows/main-build-java.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: java-${{ matrix.sample-app }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}-${{matrix.confmap}}
     strategy:
       fail-fast: false

--- a/.github/workflows/main-build-python.yml
+++ b/.github/workflows/main-build-python.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: python-wrapper-${{ matrix.architecture }}
     strategy:
       fail-fast: false

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.language }}-${{ matrix.instrumentation-type }}-${{ matrix.architecture }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Build artifacts - ${{ matrix.language }}
     strategy:
       matrix:

--- a/.github/workflows/publish-status.yml
+++ b/.github/workflows/publish-status.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   publish-status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ permissions:
 
 jobs:
   validate-inputs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Validate `layer_name_keyword` (${{ github.event.inputs.layer_name_keyword }})
         run: |
           grep -Eq "aws-otel-(collector|java-agent|java-wrapper|nodejs|python)-<ARCHITECTURE>-ver-[0-9]+-[0-9]+-[0-9]+" <<< "${{ github.event.inputs.layer_name_keyword }}"
   publish-prod:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: validate-inputs
     strategy:
       matrix:
@@ -112,7 +112,7 @@ jobs:
         run: |
           aws s3 rb --force s3://${{ env.BUCKET_NAME }}
   generate-note:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: publish-prod
     strategy:
       matrix:
@@ -177,7 +177,7 @@ jobs:
   smoke-test:
     name: Smoke Test - (${{ matrix.aws_region }} - ${{ github.event.inputs.layer_name_keyword }} - ${{ matrix.architecture }})
     needs: generate-note
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         architecture: ${{ fromJson(github.event.inputs.architecture) }}

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -16,10 +16,10 @@ on:
 permissions:
   id-token: write
   contents: read
-  
+
 jobs:
   soaking-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Soak Test - (${{ matrix.language }}, ${{ matrix.sample-app }}, ${{ matrix.instrumentation-type }}, ${{ matrix.architecture }})
     strategy:
       fail-fast: false
@@ -277,7 +277,7 @@ jobs:
   output-keywords:
     if: ${{ always() }}
     name: Output (${{ matrix.language }}, ${{ matrix.instrumentation-type }}) Layer Keyword
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - soaking-test
     strategy:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   stale-close:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Mark the issues/pr
         uses: actions/stale@v9


### PR DESCRIPTION
**Description:** 
 - Pin `ubuntu-22.04` version instead of `ubuntu-latest` to avoid any breaking changes that comes as part of `latest`. `22.04` is also supported for 2 more years.
 - Bump Ubuntu version to ubuntu-22.04 instead of 20.04>
 
 https://github.com/actions/runner-images?tab=readme-ov-file#available-images
 
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
