### PR TITLE
[chore] Fix workflows with breaking changes and Set/modify otel propagators in the build scripts

### DIFF
--- a/go/build.sh
+++ b/go/build.sh
@@ -9,4 +9,5 @@ popd || exit
 # Build sample app
 
 cd ../opentelemetry-lambda/go/sample-apps/function || exit
+go mod tidy
 CGO_ENABLED=0 ./build.sh

--- a/java/integration-tests/aws-sdk/agent-confmap/main.tf
+++ b/java/integration-tests/aws-sdk/agent-confmap/main.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
-  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
+  compatible_runtimes =  ["nodejs16.x", "nodejs18.x", "nodejs20.x", "nodejs22.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }

--- a/java/integration-tests/aws-sdk/agent-confmap/main.tf
+++ b/java/integration-tests/aws-sdk/agent-confmap/main.tf
@@ -82,7 +82,7 @@ receivers:
       http:
         endpoint: "localhost:4318"
 exporters:
-  logging:
+  debug:
   awsxray:
   prometheusremotewrite: $${${module.remote_configuration.configuration_uri}}
 
@@ -95,7 +95,7 @@ service:
       exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging, prometheusremotewrite]
+      exporters: [debug, prometheusremotewrite]
   telemetry:
     metrics:
       address: localhost:8888

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -62,7 +62,7 @@ receivers:
       http:
         endpoint: "localhost:4318"
 exporters:
-  logging:
+  debug:
   awsxray:
   prometheusremotewrite:
     endpoint: "${aws_prometheus_workspace.test_amp_workspace[0].prometheus_endpoint}api/v1/remote_write"
@@ -78,7 +78,7 @@ service:
       exporters: [awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging, prometheusremotewrite]
+      exporters: [debug, prometheusremotewrite]
   telemetry:
     metrics:
       address: localhost:8888

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
-  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
+  compatible_runtimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x", "nodejs22.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }

--- a/java/integration-tests/aws-sdk/wrapper/main.tf
+++ b/java/integration-tests/aws-sdk/wrapper/main.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
-  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
+  compatible_runtimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x", "nodejs22.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }

--- a/java/integration-tests/okhttp/wrapper/main.tf
+++ b/java/integration-tests/okhttp/wrapper/main.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
-  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
+  compatible_runtimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x", "nodejs22.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }

--- a/nodejs/integration-tests/aws-sdk/wrapper/main.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/main.tf
@@ -5,7 +5,7 @@ locals {
 resource "aws_lambda_layer_version" "sdk_layer" {
   layer_name          = var.sdk_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/nodejs/packages/layer/build/layer.zip"
-  compatible_runtimes = ["nodejs16.x", "nodejs18.x"]
+  compatible_runtimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x", "nodejs22.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/nodejs/packages/layer/build/layer.zip")
 }
@@ -14,7 +14,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
-  compatible_runtimes = ["nodejs16.x", "nodejs18.x"]
+  compatible_runtimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x", "nodejs22.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }

--- a/nodejs/scripts/otel-handler
+++ b/nodejs/scripts/otel-handler
@@ -2,4 +2,8 @@
 
 export NODE_OPTIONS="--require /opt/adot-extension.js ${NODE_OPTIONS}"
 
+if [[ -z "$OTEL_PROPAGATORS" ]]; then
+  export OTEL_PROPAGATORS="tracecontext,baggage,xray-lambda"
+fi
+
 source /opt/otel-handler-upstream

--- a/python/integration-tests/aws-sdk/wrapper/main.tf
+++ b/python/integration-tests/aws-sdk/wrapper/main.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
-  compatible_runtimes = ["nodejs14.x", "nodejs16.x", "nodejs18.x"]
+  compatible_runtimes = ["nodejs16.x", "nodejs18.x", "nodejs20.x", "nodejs22.x"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }

--- a/python/scripts/otel-instrument
+++ b/python/scripts/otel-instrument
@@ -19,7 +19,7 @@ END_DOCUMENTATION
 # - Set `OTEL_PROPAGATORS` if not yet set, and include the xray propagator
 
 if [ -z ${OTEL_PROPAGATORS} ]; then
-    export OTEL_PROPAGATORS="tracecontext,baggage,xray";
+    export OTEL_PROPAGATORS="tracecontext,baggage,xray-lambda";
 fi
 
 # - Call the upstream configure OTel script


### PR DESCRIPTION
**Description:** 

This PR updates the scripts and make more changes w/r/t to the breaking changes after [sub module update  ](https://github.com/aws-observability/aws-otel-lambda/pull/1023)
>Users (of tracer layers that have implemented xray-lambda) that send traces to X-Ray, especially if they enable Active Tracing, should override this value to OTEL_PROPAGATORS=tracecontext,baggage,xray-lambda to ensure proper span relationships within X-Ray.
- set otel propagators in the scripts[ref here](https://github.com/open-telemetry/opentelemetry-lambda/pull/1226)
-  expands nodejs runtimes for collector layer in the tf files to be inline with [supported lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
- Update go sample build script to add `go mod tidy` to fix the inconsistent go mod file upstream.
- Logging exporter is deprecated, use debug exporter in the configuration.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
