### PR TITLE
[chore] Update upstream otel sub-module, add support for nodejs 22.x runtime

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - uses: actions/setup-java@v4
         if: ${{ matrix.language == 'java' }}

--- a/.github/workflows/main-build-java.yml
+++ b/.github/workflows/main-build-java.yml
@@ -85,7 +85,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/main-build-nodejs.yml
+++ b/.github/workflows/main-build-nodejs.yml
@@ -23,14 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [ amd64, arm64 ]
-        runtime: [nodejs18.x, node20.x]
+        runtime: [nodejs18.x, node20.x, nodejs22.x]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main-build-nodejs.yml
+++ b/.github/workflows/main-build-nodejs.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         architecture: [ amd64, arm64 ]
-        runtime: [nodejs16.x, nodejs18.x]
+        runtime: [nodejs18.x, node20.x]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,7 +34,7 @@ jobs:
           check-latest: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Cache (NodeJS)
         uses: actions/cache@v4
         with:

--- a/.github/workflows/main-build-python.yml
+++ b/.github/workflows/main-build-python.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -40,7 +40,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - uses: actions/setup-dotnet@v4
         if: ${{ matrix.language == 'dotnet' }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - uses: actions/setup-java@v4
         if: ${{ matrix.language == 'java' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
         # above, always setup go 1.18.
         # if: ${{ env.TEST_LANGUAGE == 'go' }}
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - name: download layer tf file
         uses: actions/download-artifact@v4

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.10'
+          go-version: '~1.23.4'
           check-latest: true
       - uses: actions/setup-java@v4
         if: ${{ matrix.language == 'java' }}

--- a/go/build.sh
+++ b/go/build.sh
@@ -9,5 +9,4 @@ popd || exit
 # Build sample app
 
 cd ../opentelemetry-lambda/go/sample-apps/function || exit
-go mod tidy
 CGO_ENABLED=0 ./build.sh

--- a/nodejs/integration-tests/aws-sdk/wrapper/main.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/main.tf
@@ -26,6 +26,7 @@ module "hello-lambda-function" {
   collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
   sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
   tracing_mode        = var.tracing_mode
+  runtime             = var.runtime
 }
 
 resource "aws_iam_role_policy_attachment" "hello-lambda-cloudwatch-insights" {

--- a/nodejs/integration-tests/aws-sdk/wrapper/variables.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/variables.tf
@@ -34,3 +34,8 @@ variable "enable_collector_layer" {
   default     = false
 }
 
+variable "runtime" {
+  type        = string
+  description = "NodeJS runtime version used for sample Lambda Function"
+  default     = "nodejs18.x"
+}

--- a/nodejs/wrapper-adot/package.json
+++ b/nodejs/wrapper-adot/package.json
@@ -22,7 +22,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
**Description:** 

Update upstream otel sub-module, add support for nodejs 22.x runtime
- otel-js is [moving towards following runtimes](https://github.com/open-telemetry/opentelemetry-js?tab=readme-ov-file#supported-runtimes)
- support for nodejs16.x is [removed upstream](https://github.com/open-telemetry/opentelemetry-lambda/pull/1534)
- Bump go version in the workflows

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
