### PR TITLE
Fix Release worklfow with upload-artefact breaking changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.LAYER_NAME }}
+          name: ${{ env.LAYER_NAME }}-${{matrix.architecture}}-${{matrix.aws_region}}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
       - name: clean s3
         if: always()
@@ -128,8 +128,9 @@ jobs:
       - name: download layerARNs
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.LAYER_NAME }}
+          pattern: ${{ env.LAYER_NAME }}-*
           path: ${{ env.LAYER_NAME }}
+          merge-multiple: true
       - name: show layerARNs
         run: |
           for file in ${{ env.LAYER_NAME }}/*


### PR DESCRIPTION
**Description:** 

Release workflow is [currently failing](https://github.com/aws-observability/aws-otel-lambda/actions/runs/12601893469) as the upload artefact uses the same name, which is a breaking change in v4 upload-artefacts. 

Modifying the name with matrix arch, region to be unique for workflow


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
