### PR TITLE
Patch listener in collector ext to use random port

### DIFF
--- a/listener.patch
+++ b/listener.patch
@@ -1,0 +1,89 @@
+diff --git a/collector/internal/telemetryapi/listener.go b/collector/internal/telemetryapi/listener.go
+index 8499d4e..93ff0dc 100644
+--- a/collector/internal/telemetryapi/listener.go
++++ b/collector/internal/telemetryapi/listener.go
+@@ -17,18 +17,32 @@ package telemetryapi
+ import (
+ 	"context"
+ 	"encoding/json"
++	"errors"
+ 	"fmt"
+ 	"io"
++	"math/rand"
++	"net"
+ 	"net/http"
+ 	"os"
++	"syscall"
+ 	"time"
+ 
+ 	"github.com/golang-collections/go-datastructures/queue"
+ 	"go.uber.org/zap"
+ )
+ 
+-const defaultListenerPort = "53612"
+-const initialQueueSize = 5
++const (
++	initialQueueSize = 5
++	maxRetries       = 5
++	// Define ephemeral port range (typical range is 49152-65535)
++	minPort = 49152
++	maxPort = 65535
++)
++
++// getRandomPort returns a random port number within the ephemeral range
++func getRandomPort() string {
++	return fmt.Sprintf("%d", rand.Intn(maxPort-minPort)+minPort)
++}
+ 
+ // Listener is used to listen to the Telemetry API
+ type Listener struct {
+@@ -46,21 +60,44 @@ func NewListener(logger *zap.Logger) *Listener {
+ 	}
+ }
+ 
+-func listenOnAddress() string {
++func (s *Listener) tryBindPort() (string, error) {
++	for i := 0; i < maxRetries; i++ {
++		port := getRandomPort()
++		address := listenOnAddress(port)
++
++		l, err := net.Listen("tcp", address)
++		if err != nil {
++			if errors.Is(err, syscall.EADDRINUSE) {
++				s.logger.Debug("Port in use, trying another",
++					zap.String("address", address))
++				continue
++			}
++			return "", err
++		}
++		l.Close()
++		return address, nil
++	}
++
++	return "", fmt.Errorf("failed to find available port after %d attempts", maxRetries)
++}
++
++func listenOnAddress(port string) string {
+ 	envAwsLocal, ok := os.LookupEnv("AWS_SAM_LOCAL")
+ 	var addr string
+ 	if ok && envAwsLocal == "true" {
+-		addr = ":" + defaultListenerPort
++		addr = ":" + port
+ 	} else {
+-		addr = "sandbox.localdomain:" + defaultListenerPort
++		addr = "sandbox.localdomain:" + port
+ 	}
+-
+ 	return addr
+ }
+ 
+ // Start the server in a goroutine where the log events will be sent
+ func (s *Listener) Start() (string, error) {
+-	address := listenOnAddress()
++	address, err := s.tryBindPort()
++	if err != nil {
++		return "", fmt.Errorf("failed to find available port: %w", err)
++	}
+ 	s.logger.Info("Listening for requests", zap.String("address", address))
+ 	s.httpServer = &http.Server{Addr: address}
+ 	http.HandleFunc("/", s.httpHandler)

--- a/listener.patch
+++ b/listener.patch
@@ -1,5 +1,5 @@
 diff --git a/collector/internal/telemetryapi/listener.go b/collector/internal/telemetryapi/listener.go
-index 8499d4e..93ff0dc 100644
+index 8499d4e..62a6461 100644
 --- a/collector/internal/telemetryapi/listener.go
 +++ b/collector/internal/telemetryapi/listener.go
 @@ -17,18 +17,32 @@ package telemetryapi
@@ -37,12 +37,12 @@ index 8499d4e..93ff0dc 100644
  
  // Listener is used to listen to the Telemetry API
  type Listener struct {
-@@ -46,21 +60,44 @@ func NewListener(logger *zap.Logger) *Listener {
+@@ -46,26 +60,48 @@ func NewListener(logger *zap.Logger) *Listener {
  	}
  }
  
 -func listenOnAddress() string {
-+func (s *Listener) tryBindPort() (string, error) {
++func (s *Listener) tryBindPort() (net.Listener, string, error) {
 +	for i := 0; i < maxRetries; i++ {
 +		port := getRandomPort()
 +		address := listenOnAddress(port)
@@ -54,13 +54,12 @@ index 8499d4e..93ff0dc 100644
 +					zap.String("address", address))
 +				continue
 +			}
-+			return "", err
++			return nil, "", err
 +		}
-+		l.Close()
-+		return address, nil
++		return l, address, nil
 +	}
 +
-+	return "", fmt.Errorf("failed to find available port after %d attempts", maxRetries)
++	return nil, "", fmt.Errorf("failed to find available port after %d attempts", maxRetries)
 +}
 +
 +func listenOnAddress(port string) string {
@@ -80,10 +79,16 @@ index 8499d4e..93ff0dc 100644
  // Start the server in a goroutine where the log events will be sent
  func (s *Listener) Start() (string, error) {
 -	address := listenOnAddress()
-+	address, err := s.tryBindPort()
++	listener, address, err := s.tryBindPort()
 +	if err != nil {
 +		return "", fmt.Errorf("failed to find available port: %w", err)
 +	}
  	s.logger.Info("Listening for requests", zap.String("address", address))
  	s.httpServer = &http.Server{Addr: address}
  	http.HandleFunc("/", s.httpHandler)
+ 	go func() {
+-		err := s.httpServer.ListenAndServe()
++		err := s.httpServer.Serve(listener)
+ 		if err != http.ErrServerClosed {
+ 			s.logger.Error("Unexpected stop on HTTP Server", zap.Error(err))
+ 			s.Shutdown()

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -42,6 +42,10 @@ patch -p2 < ../../collector.patch
 # patch manager.go to remove lambdacomponents attribute
 patch -p2 < ../../manager.patch
 
+
+# patch listener.go to patch port usage
+patch -p2 < ../../listener.patch
+
 # Replace OTel Collector with ADOT Collector
 go mod edit -replace github.com/open-telemetry/opentelemetry-lambda/collector/lambdacomponents=${CURRENT_DIR}/adot/collector/lambdacomponents
 


### PR DESCRIPTION
**Description:** 
Patch listener.go to use random port, in order to avoid error "bind: address in use"

Tested in dev, executions now take random ports

![image](https://github.com/user-attachments/assets/5dfcf2c5-84c0-43d4-a96d-84f4b5a5d0ab)



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
