### PR TITLE
fix(soak): repair soak tests for OTel Collector v0.151.0 bump

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - uses: actions/setup-java@v4
         if: ${{ matrix.language == 'java' }}

--- a/.github/workflows/main-build-java.yml
+++ b/.github/workflows/main-build-java.yml
@@ -85,7 +85,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/main-build-nodejs.yml
+++ b/.github/workflows/main-build-nodejs.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main-build-python.yml
+++ b/.github/workflows/main-build-python.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -40,7 +40,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - uses: actions/setup-dotnet@v4
         if: ${{ matrix.language == 'dotnet' }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - uses: actions/setup-java@v4
         if: ${{ matrix.language == 'java' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,7 @@ jobs:
         # above, always setup go 1.18.
         # if: ${{ env.TEST_LANGUAGE == 'go' }}
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - name: download layer tf file
         uses: actions/download-artifact@v4

--- a/.github/workflows/soaking.yml
+++ b/.github/workflows/soaking.yml
@@ -67,7 +67,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.24.3'
+          go-version: '~1.26.2'
           check-latest: true
       - uses: actions/setup-java@v4
         if: ${{ matrix.language == 'java' }}

--- a/adot/collector/config.yaml
+++ b/adot/collector/config.yaml
@@ -18,6 +18,3 @@ service:
     metrics:
       receivers: [otlp]
       exporters: [debug]
-  telemetry:
-    metrics:
-      address: localhost:8888

--- a/adot/utils/expected-templates/nodejs-aws-sdk-wrapper.json
+++ b/adot/utils/expected-templates/nodejs-aws-sdk-wrapper.json
@@ -12,6 +12,11 @@
     "name": "lambda-nodejs.*"
   },
   {
-    "name": "s3"
+    "name": "STS",
+    "origin": "AWS::STS",
+    "inferred": true,
+    "aws": {
+      "operation": "GetCallerIdentity"
+    }
   }
 ]

--- a/java/integration-tests/aws-sdk/agent/main.tf
+++ b/java/integration-tests/aws-sdk/agent/main.tf
@@ -79,9 +79,6 @@ service:
     metrics:
       receivers: [otlp]
       exporters: [debug, prometheusremotewrite]
-  telemetry:
-    metrics:
-      address: localhost:8888
 EOT
     filename = "config.yaml"
   }

--- a/nodejs/integration-tests/aws-sdk/wrapper/main.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/main.tf
@@ -19,22 +19,54 @@ resource "aws_lambda_layer_version" "collector_layer" {
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }
 
-module "hello-lambda-function" {
-  source              = "../../../../opentelemetry-lambda/nodejs/sample-apps/aws-sdk/deploy/wrapper"
+# NOTE: The upstream `nodejs/sample-apps/aws-sdk/deploy/wrapper` module was
+# refactored (OTel Collector v0.151.0) to build layer ARNs internally from
+# published layer versions and no longer accepts `collector_layer_arn` /
+# `sdk_layer_arn` inputs. The integration/soak test must attach the layers we
+# just built locally, so we instantiate the Lambda function directly here -
+# mirroring the python integration test - instead of consuming that module.
+module "test-function" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "7.19.0"
+
+  architectures = compact([var.architecture])
+  function_name = var.function_name
+  handler       = "index.handler"
+  runtime       = var.runtime
+
+  create_package         = false
+  local_existing_package = "${path.module}/../../../../opentelemetry-lambda/nodejs/sample-apps/aws-sdk/build/function.zip"
+
+  memory_size = 384
+  timeout     = 20
+
+  layers = compact([
+    var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null,
+    aws_lambda_layer_version.sdk_layer.arn
+  ])
+
+  environment_variables = {
+    AWS_LAMBDA_EXEC_WRAPPER = "/opt/otel-handler"
+  }
+
+  tracing_mode = var.tracing_mode
+}
+
+module "api-gateway" {
+  source = "../../../../opentelemetry-lambda/utils/terraform/api-gateway-proxy"
+
   name                = var.function_name
-  architecture        = var.architecture
-  collector_layer_arn = var.enable_collector_layer ? aws_lambda_layer_version.collector_layer[0].arn : null
-  sdk_layer_arn       = aws_lambda_layer_version.sdk_layer.arn
-  tracing_mode        = var.tracing_mode
-  runtime             = var.runtime
+  function_name       = module.test-function.lambda_function_name
+  function_invoke_arn = module.test-function.lambda_function_invoke_arn
+  enable_xray_tracing = var.tracing_mode == "Active"
 }
 
 resource "aws_iam_role_policy_attachment" "hello-lambda-cloudwatch-insights" {
-  role       = module.hello-lambda-function.function_role_name
+  role       = module.test-function.lambda_role_name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "test_xray" {
-  role       = module.hello-lambda-function.function_role_name
+  role       = module.test-function.lambda_role_name
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }

--- a/nodejs/integration-tests/aws-sdk/wrapper/outputs.tf
+++ b/nodejs/integration-tests/aws-sdk/wrapper/outputs.tf
@@ -1,9 +1,9 @@
 output "api-gateway-url" {
-  value = module.hello-lambda-function.api-gateway-url
+  value = module.api-gateway.api_gateway_url
 }
 
 output "function_role_name" {
-  value = module.hello-lambda-function.function_role_name
+  value = module.test-function.lambda_role_name
 }
 
 output "collector_layer_arn" {


### PR DESCRIPTION
# ⚠️ AI-Generated Investigation — This analysis was produced by an AI agent and has not been reviewed by a human operator. Please verify with the service team before sending to customers.

## Summary

Repairs the soak/integration tests that broke after the ADOT Collector **v0.48.0 / OTel Collector v0.151.0** dependency bump merged in #1135 (CVE remediation, internal ref V2153606376). Stacks on top of `main` (which already contains #1135).

Three independent problems were found in soak run [28047386560](https://github.com/aws-observability/aws-otel-lambda/actions/runs/28047386560):

1. **CI Go version** — workflows still pinned Go `~1.24.3` while the module now requires 1.26.2.
2. **nodejs wrapper terraform breakage** — the upstream `nodejs/sample-apps/aws-sdk/deploy/wrapper` module was refactored in v0.151.0 to build layer ARNs internally from published-layer-version inputs and no longer accepts `collector_layer_arn` / `sdk_layer_arn`, so the integration test (which must attach locally-built layers) failed with `Unsupported argument`. The nodejs sample app also switched its AWS SDK call from S3 `ListBuckets` to STS `GetCallerIdentity`, invalidating the expected X-Ray trace template.
3. **Collector INIT failures (hypothesis)** — the deprecated `service.telemetry.metrics.address` field (removed upstream for v0.151.0) is the one config element common to every failing job's collector.

## Changes

| Area | Files | Change |
|------|-------|--------|
| CI | `.github/workflows/*.yml` (8) | Go `~1.24.3` → `~1.26.2` |
| nodejs soak | `nodejs/integration-tests/aws-sdk/wrapper/{main,outputs}.tf` | Instantiate `terraform-aws-modules/lambda/aws@7.19.0` + `api-gateway-proxy` directly and attach locally-built layers, mirroring the python integration test |
| nodejs trace | `adot/utils/expected-templates/nodejs-aws-sdk-wrapper.json` | Expect STS `GetCallerIdentity` segment (was S3) |
| collector config | `adot/collector/config.yaml`, `java/integration-tests/aws-sdk/agent/main.tf` | Remove deprecated `service.telemetry.metrics.address: localhost:8888` |

Go/Java deploy modules still accept the ARN inputs and their sample apps still call S3, so they are intentionally left unchanged.

## Testing

**Verified locally (static):**
- `config.yaml` remains valid after removing the `telemetry` block; traces → `awsxray`, metrics → `debug`.
- All `var.*` referenced in the reworked nodejs `main.tf` are declared in `variables.tf`.
- Module and output names (`lambda_function_name`, `lambda_function_invoke_arn`, `lambda_role_name`, `api_gateway_url`) match the shared modules and the working python wrapper test.
- expected-template JSON is well-formed.

**NOT yet verified (requires a live run):**
- `terraform validate` / `terraform init` (not run locally).
- **The collector-config fix (item 3) is an unverified hypothesis.** It addresses the `FUNCTION_ERROR_INIT_FAILURE` (java-agent) and runtime HTTP 500s (go/python/java-wrapper) seen in the failing soak, but this can only be confirmed by a fresh soak run. Please dispatch `soaking.yml` with `-t 10800` and confirm before merge.
- The nodejs expected-trace STS `GetCallerIdentity` segment name is inferred from the java/go template convention; confirm against a real trace.

> Note: the soak workflow uses AWS OIDC with base-repo secrets, so it will not run automatically on this fork-based PR — a maintainer with base-repo write access needs to dispatch it.

Fixes soak breakage from #1135.
