### PR TITLE
fix(nodejs&java): correct function.zip path in canary terraform

### DIFF
--- a/adot/utils/expected-templates/java-okhttp-wrapper.json
+++ b/adot/utils/expected-templates/java-okhttp-wrapper.json
@@ -12,6 +12,13 @@
     "name":"lambda-java.*"
   },
   {
-    "name":"aws.amazon.com"
+    "name":"GET",
+    "inferred":true,
+    "http":{
+      "request":{
+        "url":"https://aws.amazon.com/",
+        "method":"GET"
+      }
+    }
   }
 ]

--- a/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
+++ b/nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf
@@ -17,7 +17,7 @@ module "test-function" {
   runtime       = var.runtime
 
   create_package         = false
-  local_existing_package = "${path.module}/../../build/function.zip"
+  local_existing_package = "${path.module}/../../../../../opentelemetry-lambda/nodejs/sample-apps/aws-sdk/build/function.zip"
 
   memory_size = 384
   timeout     = 20


### PR DESCRIPTION
Fix the `local_existing_package` path in `nodejs/sample-apps/aws-sdk/deploy/wrapper/main.tf`.

The canary builds the nodejs function via the submodule path (`opentelemetry-lambda/nodejs/sample-apps/aws-sdk/build/function.zip`), not from the ADOT repo's own directory tree.

Error from canary run:
```
Error: reading ZIP file (./../../build/function.zip): open ./../../build/function.zip: no such file or directory
```

Follow-up to #1143.