### PR TITLE
fix(nodejs): bundle @aws-sdk/client-sts so trace validation emits STS span

### DIFF
--- a/adot/nodejs/sample-apps/aws-sdk/package.json
+++ b/adot/nodejs/sample-apps/aws-sdk/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@opentelemetry-samples/lambda-awssdk",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Sample application for AWS Lambda using AWS SDK v3.",
+  "main": "build/lambda/index.js",
+  "types": "build/lambda/index.d.ts",
+  "repository": "open-telemetry/opentelemetry-lambda",
+  "scripts": {
+    "clean": "rimraf build/*",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "build": "npm run clean && npm run compile && npm run postcompile",
+    "compile": "tsc -p .",
+    "postcompile": "copyfiles 'package*.json' build/lambda/ && npm install --production --ignore-scripts --prefix build/lambda/ && cd build/lambda && bestzip ../function.zip *"
+  },
+  "keywords": [
+    "opentelemetry",
+    "awslambda",
+    "nodejs",
+    "tracing",
+    "profiling",
+    "instrumentation"
+  ],
+  "author": "OpenTelemetry Authors",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "files": [
+    "build/lambda/**/*.js",
+    "build/lambda/**/*.d.ts",
+    "doc",
+    "LICENSE",
+    "README.md"
+  ],
+  "dependencies": {
+    "@aws-sdk/client-sts": "3.699.0"
+  },
+  "devDependencies": {
+    "@types/node": "25.9.5",
+    "aws-cdk-lib": "2.261.0",
+    "bestzip": "3.0.1",
+    "copyfiles": "2.4.1",
+    "rimraf": "6.1.3",
+    "ts-node": "10.9.2",
+    "typescript": "6.0.3"
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the long-standing nodejs soak/smoke **TraceValidator "data model not matched"** failure (fails at `[2].name`; only the API-Gateway `[0]` and Lambda `[1]` infra segments appear, never the application/STS segments `[2]/[3]/[4]`).

## Root cause
The nodejs `aws-sdk` sample app declares **no runtime dependencies**. `@aws-sdk/client-sts` is listed only under `devDependencies`, at a non-existent version (`3.1086.0`). The app's `postcompile` runs `npm install --production`, which excludes devDependencies, so `@aws-sdk/client-sts` is **never bundled into `function.zip`**. At runtime the handler's `GetCallerIdentity` STS call is therefore not instrumented, the expected STS span is never emitted, and the validator fails.

This has failed identically since the **v0.48.0** release. #1138 added the STS-calling handler (`adot/nodejs/sample-apps/aws-sdk/lambda/index.ts`) but not the dependency it relies on, so the fix was incomplete.

## Change
Adds an ADOT overlay `adot/nodejs/sample-apps/aws-sdk/package.json` (applied onto the upstream submodule by `patch-upstream.sh`'s `cp -rf adot/* opentelemetry-lambda/`) that:
- moves `@aws-sdk/client-sts` into `dependencies` at a real published version (`3.699.0`) so it is bundled into `function.zip`
- corrects `main`/`types`/`files` from the non-existent `build/src` to `build/lambda` (the app compiles `lambda/**` per its tsconfig `include`)

## Testing
Built from the nodejs workspace root (as `build.sh`/CI does): `npm install && npm run build` both succeed, and `function.zip` now bundles the full `@aws-sdk/client-sts` tree (**127 files**, previously **0**). The compiled `index.js` retains the `STSClient` / `GetCallerIdentityCommand` call and `_X_AMZN_TRACE_ID` return. Full end-to-end trace emission is exercised by the existing soak/smoke workflows on this branch.

## Notes
- Independent of the v0.49.0 release (that layer is published; nodejs was released-past with this same pre-existing smoke failure, as in v0.48.0). This fix targets `main` so future releases validate cleanly.

