### PR TITLE
fix(dotnet): update AWSLambda instrumentation namespace for OTel 1.17.0

### DIFF
--- a/adot/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Function.cs
+++ b/adot/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Function.cs
@@ -1,0 +1,48 @@
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
+using Amazon.S3;
+using OpenTelemetry;
+using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Trace;
+using System;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+
+namespace AwsSdkSample
+{
+    public class Function
+    {
+        public static TracerProvider tracerProvider;
+
+        static Function()
+        {
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
+            tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddAWSInstrumentation()
+                .AddOtlpExporter()
+                .AddAWSLambdaConfigurations()
+                .Build();
+        }
+
+        // use AwsSdkSample::AwsSdkSample.Function::TracingFunctionHandler as input Lambda handler instead
+        public APIGatewayProxyResponse TracingFunctionHandler(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            return AWSLambdaWrapper.Trace(tracerProvider, FunctionHandler, request, context);
+        }
+
+        /// <summary>
+        /// A simple function that takes a APIGatewayProxyRequest and returns a APIGatewayProxyResponse
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public APIGatewayProxyResponse FunctionHandler(APIGatewayProxyRequest request, ILambdaContext context)
+        {
+            var S3Client = new AmazonS3Client();
+            _ = S3Client.ListBucketsAsync().Result;
+            return new APIGatewayProxyResponse() { StatusCode = 200, Body = "Hello Validator!" };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the dotnet canary/soak **"Build functions" compile failure** that breaks dotnet validation in **every region and architecture** (32/32 legs).

## Root cause
The v0.49.0 submodule bump updated `OpenTelemetry.Instrumentation.AWSLambda` to **1.17.0**, which dropped the legacy `OpenTelemetry.Contrib.*` namespace. The dotnet `aws-sdk` sample app's `Function.cs` still imported `OpenTelemetry.Contrib.Instrumentation.AWSLambda.Implementation`, so compilation fails:

```
The type or namespace name 'Contrib' does not exist in the namespace 'OpenTelemetry'
  opentelemetry-lambda/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Function.cs#5
```

The canary never reaches deploy/validate — it dies at build. **dotnet validated 32/32 in v0.48.0**, so this is a regression introduced by the 1.17.0 dependency bump in the v0.49.0 submodule.

## Change
Adds ADOT overlay `adot/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/Function.cs` (applied onto the submodule by `patch-upstream.sh`'s `cp -rf adot/*`) with the corrected import:

```diff
- using OpenTelemetry.Contrib.Instrumentation.AWSLambda.Implementation;
+ using OpenTelemetry.Instrumentation.AWSLambda;
```

Both `AWSLambdaWrapper` and the `AddAWSLambdaConfigurations` extension now live in `OpenTelemetry.Instrumentation.AWSLambda` (verified against opentelemetry-dotnet-contrib source).

## Testing
No local .NET SDK available; namespace verified against the published package source. CI "Build functions" + canary `validate trace sample` on this branch will confirm end-to-end.

