### PR TITLE
fix(dotnet): target net8.0 and set OTEL_SERVICE_NAME so the wrapper sample emits spans

### DIFF
--- a/dotnet-net8.patch
+++ b/dotnet-net8.patch
@@ -1,0 +1,49 @@
+diff --git a/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf b/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf
+index 0e3791a..587acfd 100644
+--- a/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf
++++ b/dotnet/sample-apps/aws-sdk/deploy/wrapper/main.tf
+@@ -5,7 +5,7 @@ module "hello-lambda-function" {
+   architectures = compact([var.architecture])
+   function_name = var.name
+   handler       = "AwsSdkSample::AwsSdkSample.Function::TracingFunctionHandler"
+-  runtime       = "dotnet6"
++  runtime       = "dotnet8"
+ 
+   create_package         = false
+   local_existing_package = "${path.module}/../../wrapper/SampleApps/build/function.zip"
+@@ -13,6 +13,10 @@ module "hello-lambda-function" {
+   memory_size = 384
+   timeout     = 20
+ 
++  environment_variables = {
++    OTEL_SERVICE_NAME = var.name
++  }
++
+   layers = compact([
+     var.collector_layer_arn
+   ])
+diff --git a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
+index 74e8658..cef583c 100644
+--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
++++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/AwsSdkSample/AwsSdkSample.csproj
+@@ -1,6 +1,6 @@
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>net6.0</TargetFramework>
++    <TargetFramework>net8.0</TargetFramework>
+     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+     <AWSProjectType>Lambda</AWSProjectType>
+ 
+diff --git a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
+index 1056d35..54cfbf9 100755
+--- a/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
++++ b/dotnet/sample-apps/aws-sdk/wrapper/SampleApps/build.sh
+@@ -18,7 +18,7 @@ mkdir -p build/dotnet
+ dotnet publish \
+     --output "./build/dotnet" \
+     --configuration "Release" \
+-    --framework "net6.0" /p:GenerateRuntimeConfigurationFiles=true \
++    --framework "net8.0" /p:GenerateRuntimeConfigurationFiles=true \
+     --runtime linux-$DOTNET_LINUX_ARCH \
+     --self-contained false
+ cd build/dotnet

--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.405"
+      "version": "8.0.424",
+      "rollForward": "latestFeature"
     }
 }
-

--- a/dotnet/integration-tests/aws-sdk/wrapper/main.tf
+++ b/dotnet/integration-tests/aws-sdk/wrapper/main.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_layer_version" "collector_layer" {
   count               = var.enable_collector_layer ? 1 : 0
   layer_name          = var.collector_layer_name
   filename            = "${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip"
-  compatible_runtimes = ["dotnet6", "dotnetcore3.1"]
+  compatible_runtimes = ["dotnet8", "dotnet6", "dotnetcore3.1"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${path.module}/../../../../opentelemetry-lambda/collector/build/opentelemetry-collector-layer-${local.architecture}.zip")
 }

--- a/patch-upstream.sh
+++ b/patch-upstream.sh
@@ -24,6 +24,10 @@ CURRENT_DIR=$PWD
 # collector used in each Lambda layer
 cd opentelemetry-lambda
 
+# patch dotnet sample to net8.0 runtime + set OTEL_SERVICE_NAME
+# TODO(remove once upstream opentelemetry-lambda dotnet sample targets net8): fix upstream, then delete dotnet-net8.patch and this line
+patch -p1 < ../dotnet-net8.patch
+
 # patch lambda terraform module to v7.19.0
 patch -p1 < ../terraformversion.patch
 


### PR DESCRIPTION
**Description:** 
  The dotnet `aws-sdk/wrapper` integration test fails: the emitted trace contains only
  Lambda's passive Active-tracing segments — the OpenTelemetry-instrumented handler span
  and the downstream `S3` span never reach X-Ray. This PR fixes the root cause and a
  follow-on config gap so the sample emits the expected spans again.
**Link to tracking Issue:** <Issue number if applicable>

**Testing:**  Tested in local dev

<img width="1018" height="183" alt="image" src="https://github.com/user-attachments/assets/5a61f540-b87e-43e1-a23e-c8e47e5306c9" />


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
